### PR TITLE
Better handle strs when bytes are expected internally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 
 # Auto-generated
+.*.swp
 *.pyc
 __pycache__/
 
 # Build related
 *.egg-info
 build/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+# Auto-generated
+*.pyc
+__pycache__/
+
+# Build related
+*.egg-info
+build/

--- a/Demo/Lib/ldap/async/deltree.py
+++ b/Demo/Lib/ldap/async/deltree.py
@@ -28,7 +28,7 @@ class DeleteLeafs(ldap.async.AsyncSearchHandler):
     )
 
   def _processSingleResult(self,resultType,resultItem):
-    if self._entryResultTypes.has_key(resultType):
+    if resultType in self._entryResultTypes:
       # Don't process search references
       dn,entry = resultItem
       hasSubordinates = entry.get(

--- a/Demo/Lib/ldap/async/deltree.py
+++ b/Demo/Lib/ldap/async/deltree.py
@@ -15,7 +15,7 @@ class DeleteLeafs(ldap.async.AsyncSearchHandler):
 
   def startSearch(self,searchRoot,searchScope):
     if not searchScope in [ldap.SCOPE_ONELEVEL,ldap.SCOPE_SUBTREE]:
-      raise ValueError, "Parameter searchScope must be either ldap.SCOPE_ONELEVEL or ldap.SCOPE_SUBTREE."
+      raise ValueError("Parameter searchScope must be either ldap.SCOPE_ONELEVEL or ldap.SCOPE_SUBTREE.")
     self.nonLeafEntries = []
     self.deletedEntries = 0
     ldap.async.AsyncSearchHandler.startSearch(
@@ -45,7 +45,7 @@ class DeleteLeafs(ldap.async.AsyncSearchHandler):
       else:
         try:
           self._l.delete_s(dn)
-        except ldap.NOT_ALLOWED_ON_NONLEAF,e:
+        except ldap.NOT_ALLOWED_ON_NONLEAF as e:
           self.nonLeafEntries.append(dn)
         else:
           self.deletedEntries = self.deletedEntries+1

--- a/Demo/paged_search_ext_s.py
+++ b/Demo/paged_search_ext_s.py
@@ -72,7 +72,7 @@ class PagedResultsSearchObject:
             else:
               break # no more pages available
 
-      except ldap.SERVER_DOWN,e:
+      except ldap.SERVER_DOWN as e:
         try:
           self.reconnect(self._uri)
         except AttributeError:

--- a/Demo/pyasn1/dds.py
+++ b/Demo/pyasn1/dds.py
@@ -16,7 +16,7 @@ import sys,ldap,ldapurl,getpass
 try:
   ldap_url = ldapurl.LDAPUrl(sys.argv[1])
   request_ttl = int(sys.argv[2])
-except IndexError,ValueError:
+except (IndexError, ValueError):
   print 'Usage: dds.py <LDAP URL> <TTL>'
   sys.exit(1)
 
@@ -38,7 +38,7 @@ if ldap_url.cred is None:
 try:
   ldap_conn.simple_bind_s(ldap_url.who or '',ldap_url.cred or '')
 
-except ldap.INVALID_CREDENTIALS,e:
+except ldap.INVALID_CREDENTIALS as e:
   print 'Simple bind failed:',str(e)
   sys.exit(1)
 
@@ -46,7 +46,7 @@ else:
   extreq = RefreshRequest(entryName=ldap_url.dn,requestTtl=request_ttl)
   try:
     extop_resp_obj = ldap_conn.extop_s(extreq,extop_resp_class=RefreshResponse)
-  except ldap.LDAPError,e:
+  except ldap.LDAPError as e:
     print str(e)
   else:
     if extop_resp_obj.responseTtl!=request_ttl:

--- a/Demo/pyasn1/noopsearch.py
+++ b/Demo/pyasn1/noopsearch.py
@@ -42,7 +42,7 @@ if ldap_url.who and ldap_url.cred is None:
 try:
   ldap_conn.simple_bind_s(ldap_url.who or '',ldap_url.cred or '')
 
-except ldap.INVALID_CREDENTIALS,e:
+except ldap.INVALID_CREDENTIALS as e:
   print 'Simple bind failed:',str(e)
   sys.exit(1)
 
@@ -56,7 +56,7 @@ try:
     serverctrls=[SearchNoOpControl(criticality=True)],
   )
   _,_,_,search_response_ctrls = ldap_conn.result3(msg_id,all=1,timeout=SEARCH_TIMEOUT)
-except LDAPLimitErrors,e:
+except LDAPLimitErrors as e:
   ldap_conn.abandon(msg_id)
   sys.exit(1)
 

--- a/Demo/pyasn1/ppolicy.py
+++ b/Demo/pyasn1/ppolicy.py
@@ -16,7 +16,7 @@ from ldap.controls.ppolicy import PasswordPolicyError,PasswordPolicyControl
 
 try:
   ldap_url = ldapurl.LDAPUrl(sys.argv[1])
-except IndexError,ValueError:
+except (IndexError,ValueError):
   print 'Usage: ppolicy.py <LDAP URL>'
   sys.exit(1)
 
@@ -38,7 +38,7 @@ if ldap_url.cred is None:
 try:
   msgid = ldap_conn.simple_bind(ldap_url.who,ldap_url.cred,serverctrls=[PasswordPolicyControl()])
   res_type,res_data,res_msgid,res_ctrls = ldap_conn.result3(msgid)
-except ldap.INVALID_CREDENTIALS,e:
+except ldap.INVALID_CREDENTIALS as e:
   print 'Simple bind failed:',str(e)
   sys.exit(1)
 else:

--- a/Demo/pyasn1/psearch.py
+++ b/Demo/pyasn1/psearch.py
@@ -39,7 +39,7 @@ if ldap_url.cred is None:
 try:
   ldap_conn.simple_bind_s(ldap_url.who,ldap_url.cred)
 
-except ldap.INVALID_CREDENTIALS,e:
+except ldap.INVALID_CREDENTIALS as e:
   print 'Simple bind failed:',str(e)
   sys.exit(1)
 

--- a/Demo/pyasn1/sessiontrack.py
+++ b/Demo/pyasn1/sessiontrack.py
@@ -16,7 +16,7 @@ from ldap.controls.sessiontrack import SessionTrackingControl,SESSION_TRACKING_F
 
 try:
   ldap_url = ldapurl.LDAPUrl(sys.argv[1])
-except IndexError,ValueError:
+except (IndexError, ValueError):
   print 'Usage: %s <LDAP URL>' % (sys.argv[0])
   sys.exit(1)
 
@@ -38,7 +38,7 @@ if ldap_url.who and ldap_url.cred is None:
 try:
   ldap_conn.simple_bind_s(ldap_url.who or '',ldap_url.cred or '')
 
-except ldap.INVALID_CREDENTIALS,e:
+except ldap.INVALID_CREDENTIALS as e:
   print 'Simple bind failed:',str(e)
   sys.exit(1)
 

--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -123,10 +123,10 @@ signal.signal(signal.SIGINT,commenceShutdown)
 try:
   ldap_url = ldapurl.LDAPUrl(sys.argv[1])
   database_path = sys.argv[2]
-except IndexError,e:
+except IndexError:
   print 'Usage: syncrepl-client.py <LDAP URL> <pathname of database>'
   sys.exit(1)
-except ValueError,e:
+except ValueError as e:
   print 'Error parsing command-line arguments:',str(e)
   sys.exit(1)
 
@@ -138,7 +138,7 @@ while watcher_running:
     # Now we login to the LDAP server
     try:
         ldap_connection.simple_bind_s(ldap_url.who,ldap_url.cred)
-    except ldap.INVALID_CREDENTIALS, e:
+    except ldap.INVALID_CREDENTIALS as e:
         print 'Login to LDAP server failed: ', str(e)
         sys.exit(1)
     except ldap.SERVER_DOWN:
@@ -162,7 +162,7 @@ while watcher_running:
         # User asked to exit
         commenceShutdown()
         pass
-    except Exception, e:
+    except Exception as e:
         # Handle any exception
         if watcher_running:
             print 'Encountered a problem, going to retry. Error:', str(e)

--- a/Demo/sasl_bind.py
+++ b/Demo/sasl_bind.py
@@ -67,13 +67,13 @@ for ldap_uri,sasl_mech,sasl_cb_value_dict in [
   l.protocol_version = 3
   try:
     l.sasl_interactive_bind_s("", sasl_auth)
-  except ldap.LDAPError,e:
+  except ldap.LDAPError as e:
     print 'Error using SASL mechanism',sasl_auth.mech,str(e)
   else:
     print 'Sucessfully bound using SASL mechanism:',sasl_auth.mech
     try:
       print 'Result of Who Am I? ext. op:',repr(l.whoami_s())
-    except ldap.LDAPError,e:
+    except ldap.LDAPError as e:
       print 'Error using SASL mechanism',sasl_auth.mech,str(e)
     try:
       print 'OPT_X_SASL_USERNAME',repr(l.get_option(ldap.OPT_X_SASL_USERNAME))

--- a/Demo/schema.py
+++ b/Demo/schema.py
@@ -48,7 +48,7 @@ try:
       ('usage',range(2)),
     ]  
   )
-except KeyError,e:
+except KeyError as e:
   print '***KeyError',str(e)
 
 

--- a/Demo/schema_tree.py
+++ b/Demo/schema_tree.py
@@ -51,7 +51,7 @@ if subschemasubentry_dn is None:
 
 try:
   options,args=getopt.getopt(sys.argv[1:],'',['html'])
-except getopt.error,e:
+except getopt.error:
   print 'Error: %s\nUsage: schema_oc_tree.py [--html] [LDAP URL]'
 
 html_output = options and options[0][0]=='--html'

--- a/Lib/dsml.py
+++ b/Lib/dsml.py
@@ -57,7 +57,7 @@ class DSMLWriter:
 
   def _needs_base64_encoding(self,attr_type,attr_value):
     if self._base64_attrs:
-      return self._base64_attrs.has_key(lower(attr_type))
+      return lower(attr_type) in self._base64_attrs
     else:
       try:
         unicode(attr_value,'utf-8')
@@ -235,9 +235,9 @@ else:
         raise ValueError('Unknown tag %s' % (raw_name))
 
     def characters(self,ch):
-      if self.__dict__.has_key('_oc_value'):
+      if '_oc_value' in self.__dict__:
         self._oc_value = self._oc_value + ch
-      elif self.__dict__.has_key('_attr_value'):
+      elif '_attr_value' in self.__dict__:
         self._attr_value = self._attr_value + ch
       else:
         pass

--- a/Lib/dsml.py
+++ b/Lib/dsml.py
@@ -15,6 +15,8 @@ __version__ = '2.4.15'
 import string,base64
 
 
+lower = getattr(string, 'lower', lambda s: s.lower())
+
 special_entities = (
   ('&','&amp;'),
   ('<','&lt;'),
@@ -49,13 +51,13 @@ class DSMLWriter:
     self,f,base64_attrs=[],dsml_comment='',indent='    '
   ):
     self._output_file = f
-    self._base64_attrs = {}.fromkeys(map(string.lower,base64_attrs))
+    self._base64_attrs = {}.fromkeys(map(lower,base64_attrs))
     self._dsml_comment = dsml_comment
     self._indent = indent
 
   def _needs_base64_encoding(self,attr_type,attr_value):
     if self._base64_attrs:
-      return self._base64_attrs.has_key(string.lower(attr_type))
+      return self._base64_attrs.has_key(lower(attr_type))
     else:
       try:
         unicode(attr_value,'utf-8')
@@ -273,7 +275,7 @@ else:
     ):
       self._input_file = input_file
       self._max_entries = max_entries
-      self._ignored_attr_types = {}.fromkeys(map(string.lower,(ignored_attr_types or [])))
+      self._ignored_attr_types = {}.fromkeys(map(lower,(ignored_attr_types or [])))
       self._current_record = None,None
       self.records_read = 0
       self._parser = xml.sax.make_parser()

--- a/Lib/dsml.py
+++ b/Lib/dsml.py
@@ -195,7 +195,7 @@ else:
         self._oc_value = ''
       # Unhandled tags
       else:
-        raise ValueError,'Unknown tag %s' % (raw_name)
+        raise ValueError('Unknown tag %s' % (raw_name))
 
     def endElement(self,raw_name):
       assert raw_name.startswith('dsml:'),'Illegal name'
@@ -230,7 +230,7 @@ else:
         del self._oc_value
       # Unhandled tags
       else:
-        raise ValueError,'Unknown tag %s' % (raw_name)
+        raise ValueError('Unknown tag %s' % (raw_name))
 
     def characters(self,ch):
       if self.__dict__.has_key('_oc_value'):

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -82,7 +82,7 @@ class LDAPLock:
 # Create module-wide lock for serializing all calls into underlying LDAP lib
 _ldap_module_lock = LDAPLock(desc='Module wide')
 
-from functions import open,initialize,init,get_option,set_option
+from ldap.functions import open,initialize,init,get_option,set_option
 
 from ldap.dn import explode_dn,explode_rdn,str2dn,dn2str
 del str2dn

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -8,7 +8,7 @@ $Id: __init__.py,v 1.89 2014/03/12 23:11:26 stroeder Exp $
 
 # This is also the overall release version number
 
-__version__ = '2.4.16'
+__version__ = '2.4.14'
 
 import sys
 

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -8,7 +8,7 @@ $Id: __init__.py,v 1.89 2014/03/12 23:11:26 stroeder Exp $
 
 # This is also the overall release version number
 
-__version__ = '2.4.15'
+__version__ = '2.4.16'
 
 import sys
 

--- a/Lib/ldap/async.py
+++ b/Lib/ldap/async.py
@@ -139,7 +139,7 @@ class AsyncSearchHandler:
             self._afterFirstResult = 0
         if not result_list:
           break
-        if not _searchResultTypes.has_key(result_type):
+        if result_type not in _searchResultTypes:
           raise WrongResultType(result_type,_searchResultTypes.keys())
         # Loop over list of search results
         for result_item in result_list:
@@ -199,7 +199,7 @@ class Dict(AsyncSearchHandler):
     self.allEntries = {}
 
   def _processSingleResult(self,resultType,resultItem):
-    if _entryResultTypes.has_key(resultType):
+    if resultType in _entryResultTypes:
       # Search continuations are ignored
       dn,entry = resultItem
       self.allEntries[dn] = entry
@@ -217,12 +217,12 @@ class IndexedDict(Dict):
     self.index = {}.fromkeys(self.indexed_attrs,{})
 
   def _processSingleResult(self,resultType,resultItem):
-    if _entryResultTypes.has_key(resultType):
+    if resultType in _entryResultTypes:
       # Search continuations are ignored
       dn,entry = resultItem
       self.allEntries[dn] = entry
       for a in self.indexed_attrs:
-        if entry.has_key(a):
+        if a in entry:
           for v in entry[a]:
             try:
               self.index[a][v].append(dn)
@@ -283,7 +283,7 @@ class LDIFWriter(FileWriter):
     FileWriter.__init__(self,l,self._ldif_writer._output_file,headerStr,footerStr)
 
   def _processSingleResult(self,resultType,resultItem):
-    if _entryResultTypes.has_key(resultType):
+    if resultType in _entryResultTypes:
       # Search continuations are ignored
       dn,entry = resultItem
       self._ldif_writer.unparse(dn,entry)
@@ -310,7 +310,7 @@ class DSMLWriter(FileWriter):
     FileWriter.__init__(self,l,self._dsml_writer._output_file,headerStr,footerStr)
 
   def _processSingleResult(self,resultType,resultItem):
-    if _entryResultTypes.has_key(resultType):
+    if resultType in _entryResultTypes:
       # Search continuations are ignored
       dn,entry = resultItem
       self._dsml_writer.unparse(dn,entry)

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -40,10 +40,10 @@ class cidict(UserDict):
       self[key] = dict[key]
 
   def has_key(self,key):
-    return UserDict.has_key(self,key.lower())
+    return key in self
 
   def __contains__(self,key):
-    return self.has_key(key)
+    return UserDict.__contains__(self,key.lower())
 
   def get(self,key,failobj=None):
     try:
@@ -72,7 +72,7 @@ def strlist_minus(a,b):
   result = [
     elt
     for elt in a
-    if not temp.has_key(elt)
+    if elt not in temp
   ]
   return result
 
@@ -87,7 +87,7 @@ def strlist_intersection(a,b):
   result = [
     temp[elt]
     for elt in b
-    if temp.has_key(elt)
+    if elt in temp
   ]
   return result
 
@@ -120,5 +120,5 @@ if __debug__ and __name__ == '__main__':
   cix_items.sort()
   assert cix_items==[('AbCDeF',123),('xYZ',987)],ValueError(repr(cix_items))
   del cix["abcdEF"]
-  assert not cix._keys.has_key("abcdef")
-  assert not cix.has_key("AbCDef")
+  assert "abcdef" not in cix._keys
+  assert "AbCDef" not in cix

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -10,8 +10,7 @@ $Id: cidict.py,v 1.13 2009/04/17 14:34:34 stroeder Exp $
 
 __version__ = """$Revision: 1.13 $"""
 
-from UserDict import UserDict
-from string import lower
+from ldap.compat import UserDict
 
 class cidict(UserDict):
   """
@@ -24,15 +23,15 @@ class cidict(UserDict):
     self.update(default or {})
 
   def __getitem__(self,key):
-    return self.data[lower(key)]
+    return self.data[key.lower()]
 
   def __setitem__(self,key,value):
-    lower_key = lower(key)
+    lower_key = key.lower()
     self._keys[lower_key] = key
     self.data[lower_key] = value
 
   def __delitem__(self,key):
-    lower_key = lower(key)
+    lower_key = key.lower()
     del self._keys[lower_key]
     del self.data[lower_key]
 
@@ -41,7 +40,7 @@ class cidict(UserDict):
       self[key] = dict[key]
 
   def has_key(self,key):
-    return UserDict.has_key(self,lower(key))
+    return UserDict.has_key(self,key.lower())
 
   def __contains__(self,key):
     return self.has_key(key)

--- a/Lib/ldap/compat.py
+++ b/Lib/ldap/compat.py
@@ -1,0 +1,10 @@
+"""Compatibility wrappers for Py2/Py3."""
+
+import sys
+
+if sys.version_info[0] < 3:
+    from UserDict import UserDict
+    from urllib import quote, unquote
+else:
+    from collections import UserDict
+    from urllib.parse import quote, unquote

--- a/Lib/ldap/compat.py
+++ b/Lib/ldap/compat.py
@@ -4,7 +4,14 @@ import sys
 
 if sys.version_info[0] < 3:
     from UserDict import UserDict
-    from urllib import quote, unquote
+    from urllib import quote
+    from urllib import unquote as urllib_unquote
+
+    def unquote(uri):
+        """Specialized unquote that uses UTF-8 for parsing."""
+        uri = uri.encode('ascii')
+        unquoted = urllib_unquote(uri)
+        return unquoted.decode('utf-8')
 else:
     from collections import UserDict
     from urllib.parse import quote, unquote

--- a/Lib/ldap/controls/__init__.py
+++ b/Lib/ldap/controls/__init__.py
@@ -145,9 +145,9 @@ def DecodeControlTuples(ldapControlTuples,knownLDAPControls=None):
       control.controlType,control.criticality = controlType,criticality
       try:
         control.decodeControlValue(encodedControlValue)
-      except PyAsn1Error,e:
+      except PyAsn1Error:
         if criticality:
-          raise e
+          raise
       else:
         result.append(control)
   return result

--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -64,7 +64,7 @@ def _ldap_function_call(lock,func,*args,**kwargs):
     finally:
       if lock:
         lock.release()
-  except LDAPError,e:
+  except LDAPError as e:
     if __debug__ and ldap._trace_level>=2:
       ldap._trace_file.write('=> LDAPError: %s\n' % (str(e)))
     raise

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -114,15 +114,15 @@ class SimpleLDAPObject:
     return result
 
   def __setattr__(self,name,value):
-    if self.CLASSATTR_OPTION_MAPPING.has_key(name):
+    if name in self.CLASSATTR_OPTION_MAPPING:
       self.set_option(self.CLASSATTR_OPTION_MAPPING[name],value)
     else:
       self.__dict__[name] = value
 
   def __getattr__(self,name):
-    if self.CLASSATTR_OPTION_MAPPING.has_key(name):
+    if name in self.CLASSATTR_OPTION_MAPPING:
       return self.get_option(self.CLASSATTR_OPTION_MAPPING[name])
-    elif self.__dict__.has_key(name):
+    elif name in self.__dict__:
       return self.__dict__[name]
     else:
       raise AttributeError('%s has no attribute %s' % (
@@ -739,7 +739,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
     """return data representation for pickled object"""
     d = {}
     for k,v in self.__dict__.items():
-      if not self.__transient_attrs__.has_key(k):
+      if k not in self.__transient_attrs__:
         d[k] = v
     return d
 
@@ -812,7 +812,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
     return # reconnect()
 
   def _apply_method_s(self,func,*args,**kwargs):
-    if not self.__dict__.has_key('_l'):
+    if '_l' not in self.__dict__:
       self.reconnect(self._uri,retry_max=self._retry_max,retry_delay=self._retry_delay)
     try:
       return func(self,*args,**kwargs)

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -102,7 +102,7 @@ class SimpleLDAPObject:
             diagnostic_message_success = self._l.get_option(ldap.OPT_DIAGNOSTIC_MESSAGE)
       finally:
         self._ldap_object_lock.release()
-    except LDAPError,e:
+    except LDAPError as e:
       if __debug__ and self._trace_level>=2:
         self._trace_file.write('=> LDAPError - %s: %s\n' % (e.__class__.__name__,str(e)))
       raise
@@ -125,9 +125,9 @@ class SimpleLDAPObject:
     elif self.__dict__.has_key(name):
       return self.__dict__[name]
     else:
-      raise AttributeError,'%s has no attribute %s' % (
+      raise AttributeError('%s has no attribute %s' % (
         self.__class__.__name__,repr(name)
-      )
+      ))
 
   def abandon_ext(self,msgid,serverctrls=None,clientctrls=None):
     """
@@ -787,14 +787,14 @@ class ReconnectLDAPObject(SimpleLDAPObject):
             self.start_tls_s()
           # Repeat last simple or SASL bind
           self._apply_last_bind()
-        except (ldap.SERVER_DOWN,ldap.TIMEOUT),e:
+        except (ldap.SERVER_DOWN,ldap.TIMEOUT):
           if __debug__ and self._trace_level>=1:
             self._trace_file.write('*** %s reconnect to %s failed\n' % (
               counter_text,uri
             ))
           reconnect_counter = reconnect_counter-1
           if not reconnect_counter:
-            raise e
+            raise
           if __debug__ and self._trace_level>=1:
             self._trace_file.write('=> delay %s...\n' % (retry_delay))
           time.sleep(retry_delay)

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -733,7 +733,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
     self._retry_max = retry_max
     self._retry_delay = retry_delay
     self._start_tls = 0
-    self._reconnects_done = 0L
+    self._reconnects_done = 0
 
   def __getstate__(self):
     """return data representation for pickled object"""
@@ -805,7 +805,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
             self._trace_file.write('*** %s reconnect to %s successful => repeat last operation\n' % (
               counter_text,uri
             ))
-          self._reconnects_done = self._reconnects_done + 1L
+          self._reconnects_done = self._reconnects_done + 1
           break
     finally:
       self._reconnect_lock.release()

--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -15,6 +15,8 @@ from ldap import __version__
 import string,ldap,ldap.cidict
 
 
+lower = getattr(string, 'lower', lambda s: s.lower())
+
 def list_dict(l,case_insensitive=0):
   """
   return a dictionary with all items of l being the keys of the dictionary
@@ -33,10 +35,10 @@ def list_dict(l,case_insensitive=0):
 
 def addModlist(entry,ignore_attr_types=None):
   """Build modify list for call of method LDAPObject.add()"""
-  ignore_attr_types = list_dict(map(string.lower,(ignore_attr_types or [])))
+  ignore_attr_types = list_dict(map(lower,(ignore_attr_types or [])))
   modlist = []
   for attrtype in entry.keys():
-    if ignore_attr_types.has_key(string.lower(attrtype)):
+    if ignore_attr_types.has_key(lower(attrtype)):
       # This attribute type is ignored
       continue
     # Eliminate empty attr value strings in list
@@ -68,14 +70,14 @@ def modifyModlist(
       List of attribute type names for which comparison will be made
       case-insensitive
   """
-  ignore_attr_types = list_dict(map(string.lower,(ignore_attr_types or [])))
-  case_ignore_attr_types = list_dict(map(string.lower,(case_ignore_attr_types or [])))
+  ignore_attr_types = list_dict(map(lower,(ignore_attr_types or [])))
+  case_ignore_attr_types = list_dict(map(lower,(case_ignore_attr_types or [])))
   modlist = []
   attrtype_lower_map = {}
   for a in old_entry.keys():
-    attrtype_lower_map[string.lower(a)]=a
+    attrtype_lower_map[lower(a)]=a
   for attrtype in new_entry.keys():
-    attrtype_lower = string.lower(attrtype)
+    attrtype_lower = lower(attrtype)
     if ignore_attr_types.has_key(attrtype_lower):
       # This attribute type is ignored
       continue

--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -38,7 +38,7 @@ def addModlist(entry,ignore_attr_types=None):
   ignore_attr_types = list_dict(map(lower,(ignore_attr_types or [])))
   modlist = []
   for attrtype in entry.keys():
-    if ignore_attr_types.has_key(lower(attrtype)):
+    if lower(attrtype) in ignore_attr_types:
       # This attribute type is ignored
       continue
     # Eliminate empty attr value strings in list
@@ -78,12 +78,12 @@ def modifyModlist(
     attrtype_lower_map[lower(a)]=a
   for attrtype in new_entry.keys():
     attrtype_lower = lower(attrtype)
-    if ignore_attr_types.has_key(attrtype_lower):
+    if attrtype_lower in ignore_attr_types:
       # This attribute type is ignored
       continue
     # Filter away null-strings
     new_value = filter(lambda x:x!=None,new_entry[attrtype])
-    if attrtype_lower_map.has_key(attrtype_lower):
+    if attrtype_lower in attrtype_lower_map:
       old_value = old_entry.get(attrtype_lower_map[attrtype_lower],[])
       old_value = filter(lambda x:x!=None,old_value)
       del attrtype_lower_map[attrtype_lower]
@@ -96,18 +96,18 @@ def modifyModlist(
       # Replace existing attribute
       replace_attr_value = len(old_value)!=len(new_value)
       if not replace_attr_value:
-        case_insensitive = case_ignore_attr_types.has_key(attrtype_lower)
+        case_insensitive = attrtype_lower in case_ignore_attr_types
         old_value_dict=list_dict(old_value,case_insensitive)
         new_value_dict=list_dict(new_value,case_insensitive)
         delete_values = []
         for v in old_value:
-          if not new_value_dict.has_key(v):
+          if v not in new_value_dict:
             replace_attr_value = 1
             break
         add_values = []
         if not replace_attr_value:
           for v in new_value:
-            if not old_value_dict.has_key(v):
+            if v not in old_value_dict:
               replace_attr_value = 1
               break
       if replace_attr_value:
@@ -120,7 +120,7 @@ def modifyModlist(
     # Remove all attributes of old_entry which are not present
     # in new_entry at all
     for a in attrtype_lower_map.keys():
-      if ignore_attr_types.has_key(a):
+      if a in ignore_attr_types:
         # This attribute type is ignored
         continue
       attrtype = attrtype_lower_map[a]

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -344,7 +344,7 @@ class LDAPSyntax(SchemaElement):
     self.desc = d['DESC'][0]
     self.x_subst = d['X-SUBST'][0]
     self.not_human_readable = \
-      NOT_HUMAN_READABLE_LDAP_SYNTAXES.has_key(self.oid) or \
+      self.oid in NOT_HUMAN_READABLE_LDAP_SYNTAXES or \
       d['X-NOT-HUMAN-READABLE'][0]=='TRUE'
     self.x_binary_transfer_required = d['X-BINARY-TRANSFER-REQUIRED'][0]=='TRUE'
     assert self.desc is None or type(self.desc) == str
@@ -717,7 +717,7 @@ class Entry(UserDict):
 
   def has_key(self,nameoroid):
     k = self._at2key(nameoroid)
-    return self.data.has_key(k)
+    return k in self.data
 
   def get(self,nameoroid,failobj):
     try:

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -295,7 +295,7 @@ class AttributeType(SchemaElement):
     assert type(self.single_value)==BooleanType and (self.single_value==0 or self.single_value==1)
     assert type(self.no_user_mod)==BooleanType and (self.no_user_mod==0 or self.no_user_mod==1)
     assert self.syntax is None or type(self.syntax)==StringType
-    assert self.syntax_len is None or type(self.syntax_len)==type(0L)
+    assert self.syntax_len is None or type(self.syntax_len)==type(0)
     return
 
   def __str__(self):

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -6,16 +6,10 @@ See http://www.python-ldap.org/ for details.
 \$Id: models.py,v 1.47 2014/03/12 21:44:10 stroeder Exp $
 """
 
-import UserDict,ldap.cidict
+import ldap.cidict
+from ldap.compat import UserDict
 
 from ldap.schema.tokenizer import split_tokens,extract_tokens
-
-if __debug__:
-  from types import TupleType,StringType,IntType
-  try:
-    from types import BooleanType
-  except ImportError:
-    BooleanType = IntType
 
 
 NOT_HUMAN_READABLE_LDAP_SYNTAXES = {
@@ -70,7 +64,7 @@ class SchemaElement:
     return self.oid
 
   def key_attr(self,key,value,quoted=0):
-    assert value is None or type(value)==StringType,TypeError("value has to be of StringType, was %s" % repr(value))
+    assert value is None or type(value)==str,TypeError("value has to be of StringType, was %s" % repr(value))
     if value:
       if quoted:        
         return " %s '%s'" % (key,value.replace("'","\\'"))
@@ -80,7 +74,7 @@ class SchemaElement:
       return ""
 
   def key_list(self,key,values,sep=' ',quoted=0):
-    assert type(values)==TupleType,TypeError("values has to be of ListType")
+    assert type(values) == tuple,TypeError("values has to be of ListType")
     if not values:
       return ''
     if quoted:
@@ -161,13 +155,13 @@ class ObjectClass(SchemaElement):
       self.sup = ('top',)
     else:
       self.sup = d['SUP']
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert type(self.sup)==TupleType
-    assert type(self.kind)==IntType
-    assert type(self.must)==TupleType
-    assert type(self.may)==TupleType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert type(self.sup) == tuple
+    assert type(self.kind) == int
+    assert type(self.must) == tuple
+    assert type(self.may) == tuple
     return
 
   def __str__(self):
@@ -288,13 +282,13 @@ class AttributeType(SchemaElement):
     self.collective = d['COLLECTIVE']!=None
     self.no_user_mod = d['NO-USER-MODIFICATION']!=None
     self.usage = AttributeUsage.get(d['USAGE'][0],0)
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.sup)==TupleType,'attribute sup has type %s' % (type(self.sup))
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert type(self.single_value)==BooleanType and (self.single_value==0 or self.single_value==1)
-    assert type(self.no_user_mod)==BooleanType and (self.no_user_mod==0 or self.no_user_mod==1)
-    assert self.syntax is None or type(self.syntax)==StringType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.sup) == tuple,'attribute sup has type %s' % (type(self.sup))
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert type(self.single_value) == bool and (self.single_value==0 or self.single_value==1)
+    assert type(self.no_user_mod) == bool and (self.no_user_mod==0 or self.no_user_mod==1)
+    assert self.syntax is None or type(self.syntax) == str
     assert self.syntax_len is None or type(self.syntax_len)==type(0)
     return
 
@@ -353,7 +347,7 @@ class LDAPSyntax(SchemaElement):
       NOT_HUMAN_READABLE_LDAP_SYNTAXES.has_key(self.oid) or \
       d['X-NOT-HUMAN-READABLE'][0]=='TRUE'
     self.x_binary_transfer_required = d['X-BINARY-TRANSFER-REQUIRED'][0]=='TRUE'
-    assert self.desc is None or type(self.desc)==StringType
+    assert self.desc is None or type(self.desc) == str
     return
                                   
   def __str__(self):
@@ -400,10 +394,10 @@ class MatchingRule(SchemaElement):
     self.desc = d['DESC'][0]
     self.obsolete = d['OBSOLETE']!=None
     self.syntax = d['SYNTAX'][0]
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert self.syntax is None or type(self.syntax)==StringType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert self.syntax is None or type(self.syntax) == str
     return
 
   def __str__(self):
@@ -450,10 +444,10 @@ class MatchingRuleUse(SchemaElement):
     self.desc = d['DESC'][0]
     self.obsolete = d['OBSOLETE']!=None
     self.applies = d['APPLIES']
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert type(self.applies)==TupleType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert type(self.applies) == tuple
     return
 
   def __str__(self):
@@ -517,13 +511,13 @@ class DITContentRule(SchemaElement):
     self.must = d['MUST']
     self.may = d['MAY']
     self.nots = d['NOT']
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert type(self.aux)==TupleType
-    assert type(self.must)==TupleType
-    assert type(self.may)==TupleType
-    assert type(self.nots)==TupleType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert type(self.aux) == tuple
+    assert type(self.must) == tuple
+    assert type(self.may) == tuple
+    assert type(self.nots) == tuple
     return
 
   def __str__(self):
@@ -584,11 +578,11 @@ class DITStructureRule(SchemaElement):
     self.obsolete = d['OBSOLETE']!=None
     self.form = d['FORM'][0]
     self.sup = d['SUP']
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert type(self.form)==StringType
-    assert type(self.sup)==TupleType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert type(self.form) == str
+    assert type(self.sup) == tuple
     return
 
   def __str__(self):
@@ -648,12 +642,12 @@ class NameForm(SchemaElement):
     self.oc = d['OC'][0]
     self.must = d['MUST']
     self.may = d['MAY']
-    assert type(self.names)==TupleType
-    assert self.desc is None or type(self.desc)==StringType
-    assert type(self.obsolete)==BooleanType and (self.obsolete==0 or self.obsolete==1)
-    assert type(self.oc)==StringType
-    assert type(self.must)==TupleType
-    assert type(self.may)==TupleType
+    assert type(self.names) == tuple
+    assert self.desc is None or type(self.desc) == str
+    assert type(self.obsolete) == bool and (self.obsolete==0 or self.obsolete==1)
+    assert type(self.oc) == str
+    assert type(self.must) == tuple
+    assert type(self.may) == tuple
     return
 
   def __str__(self):
@@ -667,7 +661,7 @@ class NameForm(SchemaElement):
     return '( %s )' % ''.join(result)
 
 
-class Entry(UserDict.UserDict):
+class Entry(UserDict):
   """
   Schema-aware implementation of an LDAP entry class.
   

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -300,7 +300,7 @@ class SubSchema:
     while struct_oc_list:
       oid = struct_oc_list.pop()
       for child_oid in oc_tree[oid]:
-        if struct_ocs.has_key(self.getoid(ObjectClass,child_oid)):
+        if self.getoid(ObjectClass,child_oid) in struct_ocs:
           break
       else:
         result = oid
@@ -367,7 +367,7 @@ class SubSchema:
       object_class_oid = object_class_oids.pop(0)
       # Check whether the objectClass with this OID
       # has already been processed
-      if oid_cache.has_key(object_class_oid):
+      if object_class_oid in oid_cache:
         continue
       # Cache this OID as already being processed
       oid_cache[object_class_oid] = None
@@ -420,7 +420,7 @@ class SubSchema:
     # Remove all mandantory attribute types from
     # optional attribute type list
     for a in r_may.keys():
-      if r_must.has_key(a):
+      if a in r_must:
         del r_may[a]
 
     # Apply attr_type_filter to results

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -434,7 +434,7 @@ class SubSchema:
               schema_attr_type = self.sed[AttributeType][a]
             except KeyError:
               if raise_keyerror:
-                raise KeyError,'No attribute type found in sub schema by name %s' % (a)
+                raise KeyError('No attribute type found in sub schema by name %s' % (a))
               # If there's no schema element for this attribute type
               # but still KeyError is to be ignored we filter it away
               del l[a]

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -10,8 +10,6 @@ import ldap.cidict,ldap.schema
 
 from ldap.schema.models import *
 
-from UserDict import UserDict
-
 SCHEMA_CLASS_MAPPING = ldap.cidict.cidict()
 SCHEMA_ATTR_MAPPING = {}
 

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -23,9 +23,7 @@ __all__ = [
   'LDAPUrlExtension','LDAPUrlExtensions','LDAPUrl'
 ]
 
-import UserDict
-
-from urllib import quote,unquote
+from ldap.compat import UserDict, quote, unquote
 
 LDAP_SCOPE_BASE = 0
 LDAP_SCOPE_ONELEVEL = 1
@@ -134,14 +132,14 @@ class LDAPUrlExtension:
     return not self.__eq__(other)
 
 
-class LDAPUrlExtensions(UserDict.UserDict):
+class LDAPUrlExtensions(UserDict):
   """
   Models a collection of LDAP URL extensions as
   dictionary type
   """
 
   def __init__(self,default=None):
-    UserDict.UserDict.__init__(self)
+    UserDict.__init__(self)
     for k,v in (default or {}).items():
       self[k]=v
 
@@ -395,10 +393,10 @@ class LDAPUrl:
     )
 
   def __getattr__(self,name):
-    if self.attr2extype.has_key(name):
+    if name in self.attr2extype:
       extype = self.attr2extype[name]
       if self.extensions and \
-         self.extensions.has_key(extype) and \
+         extype in self.extensions and \
          not self.extensions[extype].exvalue is None:
         result = unquote(self.extensions[extype].exvalue)
       else:
@@ -410,7 +408,7 @@ class LDAPUrl:
     return result # __getattr__()
 
   def __setattr__(self,name,value):
-    if self.attr2extype.has_key(name):
+    if name in self.attr2extype:
       extype = self.attr2extype[name]
       if value is None:
         # A value of None means that extension is deleted
@@ -424,7 +422,7 @@ class LDAPUrl:
       self.__dict__[name] = value
 
   def __delattr__(self,name):
-    if self.attr2extype.has_key(name):
+    if name in self.attr2extype:
       extype = self.attr2extype[name]
       if self.extensions:
         try:

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -258,11 +258,11 @@ class LDAPUrl:
     urlscheme,host,dn,attrs,scope,filterstr,extensions
     """
     if not isLDAPUrl(ldap_url):
-      raise ValueError,'Parameter ldap_url does not seem to be a LDAP URL.'
+      raise ValueError('Parameter ldap_url does not seem to be a LDAP URL.')
     scheme,rest = ldap_url.split('://',1)
     self.urlscheme = scheme.strip()
     if not self.urlscheme in ['ldap','ldaps','ldapi']:
-      raise ValueError,'LDAP URL contains unsupported URL scheme %s.' % (self.urlscheme)
+      raise ValueError('LDAP URL contains unsupported URL scheme %s.' % (self.urlscheme))
     slash_pos = rest.find('/')
     qemark_pos = rest.find('?')
     if (slash_pos==-1) and (qemark_pos==-1):
@@ -282,7 +282,7 @@ class LDAPUrl:
         # Do not eat question mark
         rest = rest[qemark_pos:]
       else:
-        raise ValueError,'Something completely weird happened!'
+        raise ValueError('Something completely weird happened!')
     paramlist=rest.split('?',4)
     paramlist_len = len(paramlist)
     if paramlist_len>=1:
@@ -294,7 +294,7 @@ class LDAPUrl:
       try:
         self.scope = SEARCH_SCOPE[scope]
       except KeyError:
-        raise ValueError,"Search scope must be either one of base, one or sub. LDAP URL contained %s" % (repr(scope))
+        raise ValueError("Search scope must be either one of base, one or sub. LDAP URL contained %s" % (repr(scope)))
     if paramlist_len>=4:
       filterstr = paramlist[3].strip()
       if not filterstr:
@@ -404,9 +404,9 @@ class LDAPUrl:
       else:
         return None
     else:
-      raise AttributeError,"%s has no attribute %s" % (
+      raise AttributeError("%s has no attribute %s" % (
         self.__class__.__name__,name
-      )
+      ))
     return result # __getattr__()
 
   def __setattr__(self,name,value):

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -124,7 +124,7 @@ class LDIFWriter:
     returns 1 if attr_value has to be base-64 encoded because
     of special chars or because attr_type is in self._base64_attrs
     """
-    return self._base64_attrs.has_key(attr_type.lower()) or \
+    return attr_type.lower() in self._base64_attrs or \
            not safe_string_re.search(attr_value) is None
 
   def _unparseAttrTypeandValue(self,attr_type,attr_value):
@@ -328,7 +328,7 @@ class LDIFParser:
       attr_value = None
       if self._process_url_schemes:
         u = urlparse.urlparse(url)
-        if self._process_url_schemes.has_key(u[0]):
+        if u[0] in self._process_url_schemes:
           attr_value = urllib.urlopen(url).read()
     elif value_spec==':\r\n' or value_spec=='\n':
       attr_value = ''
@@ -366,13 +366,13 @@ class LDIFParser:
             raise ValueError('Read changetype: before getting valid dn: line.')
           if changetype!=None:
             raise ValueError('Two lines starting with changetype: in one record.')
-          if not valid_changetype_dict.has_key(attr_value):
+          if attr_value not in valid_changetype_dict:
             raise ValueError('changetype value %s is invalid.' % (repr(attr_value)))
           changetype = attr_value
         elif attr_value!=None and \
-             not self._ignored_attr_types.has_key(attr_type.lower()):
+             attr_type.lower() not in self._ignored_attr_types:
           # Add the attribute to the entry if not ignored attribute
-          if entry.has_key(attr_type):
+          if attr_type in entry:
             entry[attr_type].append(attr_value)
           else:
             entry[attr_type]=[attr_value]

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -165,7 +165,7 @@ class LDIFWriter:
     elif mod_len==3:
       changetype = 'modify'
     else:
-      raise ValueError,"modlist item of wrong length"
+      raise ValueError("modlist item of wrong length")
     self._unparseAttrTypeandValue('changetype',changetype)
     for mod in modlist:
       if mod_len==2:
@@ -174,7 +174,7 @@ class LDIFWriter:
         mod_op,mod_type,mod_vals = mod
         self._unparseAttrTypeandValue(MOD_OP_STR[mod_op],mod_type)
       else:
-        raise ValueError,"Subsequent modlist item of wrong length"
+        raise ValueError("Subsequent modlist item of wrong length")
       if mod_vals:
         for mod_val in mod_vals:
           self._unparseAttrTypeandValue(mod_type,mod_val)
@@ -197,7 +197,7 @@ class LDIFWriter:
     elif isinstance(record,types.ListType):
       self._unparseChangeRecord(record)
     else:
-      raise ValueError, "Argument record must be dictionary or list"
+      raise ValueError("Argument record must be dictionary or list")
     # Write empty line separating the records
     self._output_file.write(self._line_sep)
     # Count records written
@@ -354,20 +354,20 @@ class LDIFParser:
         if attr_type=='dn':
           # attr type and value pair was DN of LDIF record
           if dn!=None:
-            raise ValueError, 'Two lines starting with dn: in one record.'
+            raise ValueError('Two lines starting with dn: in one record.')
           if not is_dn(attr_value):
-            raise ValueError, 'No valid string-representation of distinguished name %s.' % (repr(attr_value))
+            raise ValueError('No valid string-representation of distinguished name %s.' % (repr(attr_value)))
           dn = attr_value
         elif attr_type=='version' and dn is None:
           version = 1
         elif attr_type=='changetype':
           # attr type and value pair was DN of LDIF record
           if dn is None:
-            raise ValueError, 'Read changetype: before getting valid dn: line.'
+            raise ValueError('Read changetype: before getting valid dn: line.')
           if changetype!=None:
-            raise ValueError, 'Two lines starting with changetype: in one record.'
+            raise ValueError('Two lines starting with changetype: in one record.')
           if not valid_changetype_dict.has_key(attr_value):
-            raise ValueError, 'changetype value %s is invalid.' % (repr(attr_value))
+            raise ValueError('changetype value %s is invalid.' % (repr(attr_value)))
           changetype = attr_value
         elif attr_value!=None and \
              not self._ignored_attr_types.has_key(attr_type.lower()):

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1341,23 +1341,6 @@ static PyMethodDef methods[] = {
     { NULL, NULL }
 };
 
-/* get attribute */
-
-static PyObject*
-getattr(LDAPObject* self, char* name) 
-{
-        return Py_FindMethod(methods, (PyObject*)self, name);
-}
-
-/* set attribute */
-
-static int
-setattr(LDAPObject* self, char* name, PyObject* value) 
-{
-        PyErr_SetString(PyExc_AttributeError, name);
-        return -1;
-}
-
 /* type entry */
 
 PyTypeObject LDAP_Type = {
@@ -1373,12 +1356,28 @@ PyTypeObject LDAP_Type = {
         /* methods */
         (destructor)dealloc,    /*tp_dealloc*/
         0,                      /*tp_print*/
-        (getattrfunc)getattr,   /*tp_getattr*/
-        (setattrfunc)setattr,   /*tp_setattr*/
+        0,                      /*tp_getattr*/
+        0,                      /*tp_setattr*/
         0,                      /*tp_compare*/
         0,                      /*tp_repr*/
         0,                      /*tp_as_number*/
         0,                      /*tp_as_sequence*/
         0,                      /*tp_as_mapping*/
         0,                      /*tp_hash*/
+        0,                      /*tp_call*/
+        0,                      /*tp_str*/
+        0,                      /*tp_getattro*/
+        0,                      /*tp_setattro*/
+        0,                      /*tp_as_buffer*/
+        0,                      /*tp_flags*/
+        0,                      /*tp_doc*/
+        0,                      /*tp_traverse*/
+        0,                      /*tp_clear*/
+        0,                      /*tp_richcompare*/
+        0,                      /*tp_weaklistoffset*/
+        0,                      /*tp_iter*/
+        0,                      /*tp_iternext*/
+        methods,                /*tp_methods*/
+        0,                      /*tp_members*/
+        0,                      /*tp_getset*/
 };

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1360,11 +1360,10 @@ setattr(LDAPObject* self, char* name, PyObject* value)
 PyTypeObject LDAP_Type = {
 #if defined(MS_WINDOWS) || defined(__CYGWIN__)
         /* see http://www.python.org/doc/FAQ.html#3.24 */
-        PyObject_HEAD_INIT(NULL)
+        PyVarObject_HEAD_INIT(NULL, 0)
 #else /* ! MS_WINDOWS */
-        PyObject_HEAD_INIT(&PyType_Type)
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
 #endif /* MS_WINDOWS */
-        0,                      /*ob_size*/
         "LDAP",                 /*tp_name*/
         sizeof(LDAPObject),     /*tp_basicsize*/
         0,                      /*tp_itemsize*/

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -105,7 +105,7 @@ Tuple_to_LDAPMod( PyObject* tup, int no_op )
 {
     int op;
     char *type;
-    PyObject *list, *item;
+    PyObject *list, *item, *bytes;
     LDAPMod *lm = NULL;
     Py_ssize_t i, len, nstrs;
 
@@ -139,7 +139,7 @@ Tuple_to_LDAPMod( PyObject* tup, int no_op )
 
     if (list == Py_None) {
         /* None indicates a NULL mod_bvals */
-    } else if (PyString_Check(list)) {
+    } else if (PyUnicode_Check(list)) {
         /* Single string is a singleton list */
         lm->mod_bvalues = PyMem_NEW(struct berval *, 2);
         if (lm->mod_bvalues == NULL)
@@ -147,9 +147,10 @@ Tuple_to_LDAPMod( PyObject* tup, int no_op )
         lm->mod_bvalues[0] = PyMem_NEW(struct berval, 1);
         if (lm->mod_bvalues[0] == NULL)
             goto nomem;
+        bytes = PyUnicode_AsUTF8String(list);
         lm->mod_bvalues[1] = NULL;
-        lm->mod_bvalues[0]->bv_len = PyString_Size(list);
-        lm->mod_bvalues[0]->bv_val = PyString_AsString(list);
+        lm->mod_bvalues[0]->bv_len = PyBytes_Size(bytes);
+        lm->mod_bvalues[0]->bv_val = PyBytes_AsString(bytes);
     } else if (PySequence_Check(list)) {
         nstrs = PySequence_Length(list);
         lm->mod_bvalues = PyMem_NEW(struct berval *, nstrs + 1);
@@ -163,14 +164,15 @@ Tuple_to_LDAPMod( PyObject* tup, int no_op )
           item = PySequence_GetItem(list, i);
           if (item == NULL)
               goto error;
-          if (!PyString_Check(item)) {
+          if (!PyUnicode_Check(item)) {
               PyErr_SetObject( PyExc_TypeError, Py_BuildValue( "sO",
                   "expected a string in the list", item));
               Py_DECREF(item);
               goto error;
           }
-          lm->mod_bvalues[i]->bv_len = PyString_Size(item);
-          lm->mod_bvalues[i]->bv_val = PyString_AsString(item);
+          bytes = PyUnicode_AsUTF8String(item);
+          lm->mod_bvalues[i]->bv_len = PyBytes_Size(bytes);
+          lm->mod_bvalues[i]->bv_val = PyBytes_AsString(bytes);
           Py_DECREF(item);
         }
         if (nstrs == 0)
@@ -260,11 +262,11 @@ attrs_from_List( PyObject *attrlist, char***attrsp ) {
 
     char **attrs = NULL;
     Py_ssize_t i, len;
-    PyObject *item;
+    PyObject *item, *bytes;
 
     if (attrlist == Py_None) {
         /* None means a NULL attrlist */
-    } else if (PyString_Check(attrlist)) {
+    } else if (PyUnicode_Check(attrlist)) {
         /* caught by John Benninghoff <johnb@netscape.com> */
         PyErr_SetObject( PyExc_TypeError, Py_BuildValue("sO",
                   "expected *list* of strings, not a string", attrlist ));
@@ -280,13 +282,14 @@ attrs_from_List( PyObject *attrlist, char***attrsp ) {
             item = PySequence_GetItem(attrlist, i);
             if (item == NULL)
                 goto error;
-            if (!PyString_Check(item)) {
+            if (!PyUnicode_Check(item)) {
                 PyErr_SetObject(PyExc_TypeError, Py_BuildValue("sO",
                                 "expected string in list", item));
                 Py_DECREF(item);
                 goto error;
             }
-            attrs[i] = PyString_AsString(item);
+            bytes = PyUnicode_AsUTF8String(item);
+            attrs[i] = PyBytes_AsString(bytes);
             Py_DECREF(item);
         }
         attrs[len] = NULL;
@@ -445,7 +448,7 @@ l_ldap_add_ext( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_add_ext" );
 
-    return PyInt_FromLong(msgid);
+    return PyLong_FromLong(msgid);
 }
 
 /* ldap_simple_bind */
@@ -488,7 +491,7 @@ l_ldap_simple_bind( LDAPObject* self, PyObject* args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_simple_bind" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 
@@ -567,7 +570,7 @@ static int interaction ( unsigned flags,
   if (result == NULL) 
     /*searching for a better error code */
     return LDAP_OPERATIONS_ERROR; 
-  c_result = PyString_AsString(result); /*xxx Error checking?? */
+  c_result = PyBytes_AsString(result); /*xxx Error checking?? */
   
   /* according to the sasl docs, we should malloc() the returned
      string only for calls where interact->id == SASL_CB_PASS, so we
@@ -662,7 +665,7 @@ l_ldap_sasl_interactive_bind_s( LDAPObject* self, PyObject* args )
     /* now we extract the sasl mechanism from the SASL Object */
     mechanism = PyObject_GetAttrString(SASLObject, "mech");
     if (mechanism == NULL) return NULL;
-    c_mechanism = PyString_AsString(mechanism);
+    c_mechanism = PyBytes_AsString(mechanism);
     Py_DECREF(mechanism);
     mechanism = NULL;
 
@@ -685,7 +688,7 @@ l_ldap_sasl_interactive_bind_s( LDAPObject* self, PyObject* args )
 
     if (msgid != LDAP_SUCCESS)
         return LDAPerror( self->ldap, "ldap_sasl_interactive_bind_s" );
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 #endif
 
@@ -729,7 +732,7 @@ l_ldap_cancel( LDAPObject* self, PyObject* args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_cancel" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 #endif
@@ -775,7 +778,7 @@ l_ldap_compare_ext( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_compare_ext" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 
@@ -816,7 +819,7 @@ l_ldap_delete_ext( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_delete_ext" );
 
-    return PyInt_FromLong(msgid);
+    return PyLong_FromLong(msgid);
 }
 
 
@@ -864,7 +867,7 @@ l_ldap_modify_ext( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_modify_ext" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 
@@ -908,7 +911,7 @@ l_ldap_rename( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_rename" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 
@@ -1103,7 +1106,7 @@ l_ldap_search_ext( LDAPObject* self, PyObject* args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_search_ext" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }       
 
 
@@ -1257,7 +1260,7 @@ l_ldap_passwd( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_passwd" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 
@@ -1305,7 +1308,7 @@ l_ldap_extended_operation( LDAPObject* self, PyObject *args )
     if ( ldaperror!=LDAP_SUCCESS )
         return LDAPerror( self->ldap, "ldap_extended_operation" );
 
-    return PyInt_FromLong( msgid );
+    return PyLong_FromLong( msgid );
 }
 
 /* methods */

--- a/Modules/berval.c
+++ b/Modules/berval.c
@@ -90,7 +90,7 @@ LDAPberval_to_object(const struct berval *bv)
         Py_INCREF(ret);
     }
     else {
-        ret = PyString_FromStringAndSize(bv->bv_val, bv->bv_len);
+        ret = PyUnicode_FromStringAndSize(bv->bv_val, bv->bv_len);
     }
 
     return ret;

--- a/Modules/berval.c
+++ b/Modules/berval.c
@@ -90,6 +90,28 @@ LDAPberval_to_object(const struct berval *bv)
         Py_INCREF(ret);
     }
     else {
+        ret = PyBytes_FromStringAndSize(bv->bv_val, bv->bv_len);
+    }
+
+    return ret;
+}
+
+/*
+ * Same as LDAPberval_to_object, but returns a Unicode PyObject.
+ * Use when the value is known to be text (for instance a distinguishedName).
+ *
+ * Returns a new Python object on success, or NULL on failure.
+ */
+PyObject *
+LDAPberval_to_unicode_object(const struct berval *bv)
+{
+    PyObject *ret = NULL;
+
+    if (!bv) {
+        ret = Py_None;
+        Py_INCREF(ret);
+    }
+    else {
         ret = PyUnicode_FromStringAndSize(bv->bv_val, bv->bv_len);
     }
 

--- a/Modules/berval.h
+++ b/Modules/berval.h
@@ -11,5 +11,6 @@ int  LDAPberval_from_object(PyObject *obj, struct berval *bv);
 int  LDAPberval_from_object_check(PyObject *obj);
 void LDAPberval_release(struct berval *bv);
 PyObject *LDAPberval_to_object(const struct berval *bv);
+PyObject *LDAPberval_to_unicode_object(const struct berval *bv);
 
 #endif /* __h_berval_ */

--- a/Modules/common.h
+++ b/Modules/common.h
@@ -35,5 +35,12 @@ typedef int Py_ssize_t;
 void LDAPadd_methods( PyObject*d, PyMethodDef*methods );
 #define PyNone_Check(o) ((o) == Py_None)
 
+/* Py2/3 compatibility */
+#if PY_VERSION_HEX < 0x03000000
+#define PyBytes_Check PyString_Check
+#define PyBytes_Size PyString_Size
+#define PyBytes_AsString PyString_AsString
+#endif
+
 #endif /* __h_common_ */
 

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -14,7 +14,7 @@ static PyObject* forward;
 
 PyObject*
 LDAPconstant( int val ) {
-    PyObject *i = PyInt_FromLong( val );
+    PyObject *i = PyLong_FromLong( val );
     PyObject *s = PyObject_GetItem( reverse, i );
     if (s == NULL) {
       PyErr_Clear();
@@ -39,7 +39,7 @@ LDAPinit_constants( PyObject* d )
 
 #define add_int(d, name) \
   { \
-    PyObject *i = PyInt_FromLong(LDAP_##name); \
+    PyObject *i = PyLong_FromLong(LDAP_##name); \
     PyDict_SetItemString( d, #name, i ); \
     Py_DECREF(i); \
   }
@@ -92,7 +92,7 @@ LDAPinit_constants( PyObject* d )
 
   /* reversibles */
 
-  zero = PyInt_FromLong( 0 );
+  zero = PyLong_FromLong( 0 );
   PyDict_SetItem( reverse, zero, Py_None );
   Py_DECREF( zero );
 
@@ -265,11 +265,11 @@ LDAPinit_constants( PyObject* d )
   add_int(d,AVA_NONPRINTABLE);
   
   /*add_int(d,OPT_ON);*/
-  obj = PyInt_FromLong(1);
+  obj = PyLong_FromLong(1);
   PyDict_SetItemString( d, "OPT_ON", obj );
   Py_DECREF(obj);
   /*add_int(d,OPT_OFF);*/
-  obj = PyInt_FromLong(0);
+  obj = PyLong_FromLong(0);
   PyDict_SetItemString( d, "OPT_OFF", obj );      
   Py_DECREF(obj);
   
@@ -282,102 +282,102 @@ LDAPinit_constants( PyObject* d )
 
   /* author */
 
-  author = PyString_FromString("python-ldap Project");
+  author = PyUnicode_FromString("python-ldap Project");
   PyDict_SetItemString(d, "__author__", author);
   Py_DECREF(author);
 
   /* add_int(d,LIBLDAP_R); */
 #ifdef HAVE_LIBLDAP_R
-  obj = PyInt_FromLong(1);
+  obj = PyLong_FromLong(1);
 #else
-  obj = PyInt_FromLong(0);
+  obj = PyLong_FromLong(0);
 #endif
   PyDict_SetItemString( d, "LIBLDAP_R", obj );
   Py_DECREF(obj);
 
   /* add_int(d,SASL); */
 #ifdef HAVE_SASL
-  obj = PyInt_FromLong(1);
+  obj = PyLong_FromLong(1);
 #else
-  obj = PyInt_FromLong(0);
+  obj = PyLong_FromLong(0);
 #endif
   PyDict_SetItemString( d, "SASL_AVAIL", obj );
   Py_DECREF(obj);
 
   /* add_int(d,TLS); */
 #ifdef HAVE_TLS
-  obj = PyInt_FromLong(1);
+  obj = PyLong_FromLong(1);
 #else
-  obj = PyInt_FromLong(0);
+  obj = PyLong_FromLong(0);
 #endif
   PyDict_SetItemString( d, "TLS_AVAIL", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_MANAGEDSAIT);
+  obj = PyUnicode_FromString(LDAP_CONTROL_MANAGEDSAIT);
   PyDict_SetItemString( d, "CONTROL_MANAGEDSAIT", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_PROXY_AUTHZ);
+  obj = PyUnicode_FromString(LDAP_CONTROL_PROXY_AUTHZ);
   PyDict_SetItemString( d, "CONTROL_PROXY_AUTHZ", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_SUBENTRIES);
+  obj = PyUnicode_FromString(LDAP_CONTROL_SUBENTRIES);
   PyDict_SetItemString( d, "CONTROL_SUBENTRIES", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_VALUESRETURNFILTER);
+  obj = PyUnicode_FromString(LDAP_CONTROL_VALUESRETURNFILTER);
   PyDict_SetItemString( d, "CONTROL_VALUESRETURNFILTER", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_ASSERT);
+  obj = PyUnicode_FromString(LDAP_CONTROL_ASSERT);
   PyDict_SetItemString( d, "CONTROL_ASSERT", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_PRE_READ);
+  obj = PyUnicode_FromString(LDAP_CONTROL_PRE_READ);
   PyDict_SetItemString( d, "CONTROL_PRE_READ", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_POST_READ);
+  obj = PyUnicode_FromString(LDAP_CONTROL_POST_READ);
   PyDict_SetItemString( d, "CONTROL_POST_READ", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_SORTREQUEST);
+  obj = PyUnicode_FromString(LDAP_CONTROL_SORTREQUEST);
   PyDict_SetItemString( d, "CONTROL_SORTREQUEST", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_SORTRESPONSE);
+  obj = PyUnicode_FromString(LDAP_CONTROL_SORTRESPONSE);
   PyDict_SetItemString( d, "CONTROL_SORTRESPONSE", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_PAGEDRESULTS);
+  obj = PyUnicode_FromString(LDAP_CONTROL_PAGEDRESULTS);
   PyDict_SetItemString( d, "CONTROL_PAGEDRESULTS", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_SYNC);
+  obj = PyUnicode_FromString(LDAP_CONTROL_SYNC);
   PyDict_SetItemString( d, "CONTROL_SYNC", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_SYNC_STATE);
+  obj = PyUnicode_FromString(LDAP_CONTROL_SYNC_STATE);
   PyDict_SetItemString( d, "CONTROL_SYNC_STATE", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_SYNC_DONE);
+  obj = PyUnicode_FromString(LDAP_CONTROL_SYNC_DONE);
   PyDict_SetItemString( d, "CONTROL_SYNC_DONE", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_SYNC_INFO);
+  obj = PyUnicode_FromString(LDAP_SYNC_INFO);
   PyDict_SetItemString( d, "SYNC_INFO", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_PASSWORDPOLICYREQUEST);
+  obj = PyUnicode_FromString(LDAP_CONTROL_PASSWORDPOLICYREQUEST);
   PyDict_SetItemString( d, "CONTROL_PASSWORDPOLICYREQUEST", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_PASSWORDPOLICYRESPONSE);
+  obj = PyUnicode_FromString(LDAP_CONTROL_PASSWORDPOLICYRESPONSE);
   PyDict_SetItemString( d, "CONTROL_PASSWORDPOLICYRESPONSE", obj );
   Py_DECREF(obj);
 
-  obj = PyString_FromString(LDAP_CONTROL_RELAX);
+  obj = PyUnicode_FromString(LDAP_CONTROL_RELAX);
   PyDict_SetItemString( d, "CONTROL_RELAX", obj );
   Py_DECREF(obj);
 

--- a/Modules/errors.c
+++ b/Modules/errors.c
@@ -75,7 +75,7 @@ LDAPerror( LDAP *l, char *msg )
     if (info == NULL)
       return NULL;
 
-    str = PyString_FromString(ldap_err2string(errnum));
+    str = PyUnicode_FromString(ldap_err2string(errnum));
     if (str)
       PyDict_SetItemString( info, "desc", str );
     Py_XDECREF(str);
@@ -83,7 +83,7 @@ LDAPerror( LDAP *l, char *msg )
     if (ldap_get_option(l, LDAP_OPT_MATCHED_DN, &matched) >= 0
       && matched != NULL) {
         if (*matched != '\0') {
-      str = PyString_FromString(matched);
+      str = PyUnicode_FromString(matched);
       if (str)
           PyDict_SetItemString( info, "matched", str );
       Py_XDECREF(str);
@@ -92,14 +92,14 @@ LDAPerror( LDAP *l, char *msg )
     }
     
     if (errnum == LDAP_REFERRAL) {
-        str = PyString_FromString(msg);
+        str = PyUnicode_FromString(msg);
         if (str)
       PyDict_SetItemString( info, "info", str );
         Py_XDECREF(str);
     } else if (ldap_get_option(l, LDAP_OPT_ERROR_STRING, &error) >= 0
       && error != NULL) {
         if (error != '\0') {
-      str = PyString_FromString(error);
+      str = PyUnicode_FromString(error);
       if (str)
           PyDict_SetItemString( info, "info", str );
       Py_XDECREF(str);

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -77,9 +77,9 @@ l_ldap_str2dn( PyObject* unused, PyObject *args )
 	    LDAPAVA *ava = rdn[j];
 	    PyObject *tuple;
 
-	    tuple = Py_BuildValue("(O&O&i)", 
-		LDAPberval_to_object, &ava->la_attr,
-		LDAPberval_to_object, &ava->la_value,
+	    tuple = Py_BuildValue("(O&O&i)",
+		LDAPberval_to_unicode_object, &ava->la_attr,
+		LDAPberval_to_unicode_object, &ava->la_value,
 		ava->la_flags & ~(LDAP_AVA_FREE_ATTR|LDAP_AVA_FREE_VALUE));
 	    if (!tuple) {
 		Py_DECREF(rdnlist);

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -69,6 +69,7 @@ Tuple_to_LDAPControl( PyObject* tup )
     char iscritical;
     struct berval berbytes;
     PyObject *bytes;
+    PyObject *bytes_utf8;
     LDAPControl *lc = NULL;
     Py_ssize_t len;
 
@@ -103,9 +104,10 @@ Tuple_to_LDAPControl( PyObject* tup )
         berbytes.bv_len = 0;
         berbytes.bv_val = NULL;
     }
-    else if (PyString_Check(bytes)) {
-        berbytes.bv_len = PyString_Size(bytes);
-        berbytes.bv_val = PyString_AsString(bytes);
+    else if (PyUnicode_Check(bytes)) {
+        bytes_utf8 = PyUnicode_AsUTF8String(bytes);
+        berbytes.bv_len = PyBytes_Size(bytes);
+        berbytes.bv_val = PyBytes_AsString(bytes);
     }
     else {
 	PyErr_SetObject(PyExc_TypeError, Py_BuildValue("sO",

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -104,14 +104,13 @@ Tuple_to_LDAPControl( PyObject* tup )
         berbytes.bv_len = 0;
         berbytes.bv_val = NULL;
     }
-    else if (PyUnicode_Check(bytes)) {
-        bytes_utf8 = PyUnicode_AsUTF8String(bytes);
-        berbytes.bv_len = PyBytes_Size(bytes_utf8);
-        berbytes.bv_val = PyBytes_AsString(bytes_utf8);
+    else if (PyBytes_Check(bytes)) {
+        berbytes.bv_len = PyBytes_Size(bytes);
+        berbytes.bv_val = PyBytes_AsString(bytes);
     }
     else {
 	PyErr_SetObject(PyExc_TypeError, Py_BuildValue("sO",
-            "expected a string", bytes));
+            "expected bytes", bytes));
         LDAPControl_DEL(lc);
         return NULL;
     }

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -106,8 +106,8 @@ Tuple_to_LDAPControl( PyObject* tup )
     }
     else if (PyUnicode_Check(bytes)) {
         bytes_utf8 = PyUnicode_AsUTF8String(bytes);
-        berbytes.bv_len = PyBytes_Size(bytes);
-        berbytes.bv_val = PyBytes_AsString(bytes);
+        berbytes.bv_len = PyBytes_Size(bytes_utf8);
+        berbytes.bv_val = PyBytes_AsString(bytes_utf8);
     }
     else {
 	PyErr_SetObject(PyExc_TypeError, Py_BuildValue("sO",

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -11,7 +11,7 @@
 
 #include "LDAPObject.h"
 
-DL_EXPORT(void) init_ldap(void);
+PyAPI_FUNC(void) init_ldap(void);
 
 /* dummy module methods */
 
@@ -21,7 +21,7 @@ static PyMethodDef methods[]  = {
 
 /* module initialisation */
 
-DL_EXPORT(void)
+PyAPI_FUNC(void)
 init_ldap()
 {
 	PyObject *m, *d;

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -11,7 +11,7 @@
 
 #include "LDAPObject.h"
 
-PyAPI_FUNC(void) init_ldap(void);
+PyMODINIT_FUNC PyInit__ldap(void);
 
 /* dummy module methods */
 
@@ -21,8 +21,9 @@ static PyMethodDef methods[]  = {
 
 /* module initialisation */
 
-PyAPI_FUNC(void)
-init_ldap()
+
+PyMODINIT_FUNC
+PyInit__ldap()
 {
 	PyObject *m, *d;
 
@@ -31,7 +32,20 @@ init_ldap()
 #endif
 
 	/* Create the module and add the functions */
+#if PY_MAJOR_VERSION >= 3
+        static struct PyModuleDef ldap_moduledef = {
+                PyModuleDef_HEAD_INIT,
+                "_ldap",              /* m_name */
+                "",                   /* m_doc */
+                -1,                   /* m_size */
+                methods,              /* m_methods */
+        };
+        m = PyModule_Create(&ldap_moduledef);
+#else
 	m = Py_InitModule("_ldap", methods);
+#endif
+
+        PyType_Ready(&LDAP_Type);
 
 	/* Add some symbolic constants to the module */
 	d = PyModule_GetDict(m);
@@ -46,4 +60,6 @@ init_ldap()
 	/* Check for errors */
 	if (PyErr_Occurred())
 		Py_FatalError("can't initialize module _ldap");
+
+        return m;
 }

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -26,12 +26,8 @@ static PyMethodDef methods[]  = {
 /* module initialisation */
 
 
-PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
-PyInit__ldap()
-#else
-init_ldap()
-#endif
+/* Common initialization code */
+PyObject* init_ldap_module()
 {
 	PyObject *m, *d;
 
@@ -71,3 +67,14 @@ init_ldap()
 
         return m;
 }
+
+
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC init_ldap() {
+    init_ldap_module();
+}
+#else
+PyMODINIT_FUNC PyInit__ldap() {
+    return init_ldap_module();
+}
+#endif

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -11,7 +11,11 @@
 
 #include "LDAPObject.h"
 
+#if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC PyInit__ldap(void);
+#else
+PyMODINIT_FUNC init_ldap(void);
+#endif
 
 /* dummy module methods */
 
@@ -23,7 +27,11 @@ static PyMethodDef methods[]  = {
 
 
 PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
 PyInit__ldap()
+#else
+init_ldap()
+#endif
 {
 	PyObject *m, *d;
 

--- a/Modules/message.c
+++ b/Modules/message.c
@@ -192,7 +192,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 	 if (refs) {
 	     Py_ssize_t i;
 	     for (i=0; refs[i] != NULL; i++) {
-		 PyObject *refstr = PyString_FromString(refs[i]);
+		 PyObject *refstr = PyUnicode_FromString(refs[i]);
 		 PyList_Append(reflist, refstr);
 		 Py_DECREF(refstr);
 	     }

--- a/Modules/message.c
+++ b/Modules/message.c
@@ -192,6 +192,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 	 if (refs) {
 	     Py_ssize_t i;
 	     for (i=0; refs[i] != NULL; i++) {
+                 /* A referal is a distinguishedName => unicode */
 		 PyObject *refstr = PyUnicode_FromString(refs[i]);
 		 PyList_Append(reflist, refstr);
 		 Py_DECREF(refstr);

--- a/Modules/options.c
+++ b/Modules/options.c
@@ -205,7 +205,7 @@ LDAP_get_option(LDAPObject *self, int option)
 	    extensions = PyTuple_New(num_extensions);
 	    for (i = 0; i < num_extensions; i++)
 		PyTuple_SET_ITEM(extensions, i,
-		    PyString_FromString(apiinfo.ldapai_extensions[i]));
+		    PyUnicode_FromString(apiinfo.ldapai_extensions[i]));
 
 	    /* return api info as a dictionary */
 	    v = Py_BuildValue("{s:i, s:i, s:i, s:s, s:i, s:O}",
@@ -271,7 +271,7 @@ LDAP_get_option(LDAPObject *self, int option)
 	    if (self) LDAP_END_ALLOW_THREADS(self);
 	    if (res != LDAP_OPT_SUCCESS)
 		return option_error(res, "ldap_get_option");
-	    return PyInt_FromLong(intval);
+	    return PyLong_FromLong(intval);
 
     case LDAP_OPT_HOST_NAME:
     case LDAP_OPT_URI:
@@ -321,7 +321,7 @@ LDAP_get_option(LDAPObject *self, int option)
 		Py_INCREF(Py_None);
 		return Py_None;
 	    }
-	    v = PyString_FromString(strval);
+	    v = PyUnicode_FromString(strval);
 	    ldap_memfree(strval);
 	    return v;
 

--- a/Modules/schema.c
+++ b/Modules/schema.c
@@ -22,7 +22,7 @@ PyObject* c_string_array_to_python(char **string_array)
     py_list = PyList_New(count);
     count = 0;
     for (s=string_array; *s != 0; s++){
-      PyList_SetItem(py_list, count, PyString_FromString(*s));
+      PyList_SetItem(py_list, count, PyUnicode_FromString(*s));
       count++;
     }
   } else py_list=PyList_New(0);
@@ -52,7 +52,7 @@ PyObject* schema_extension_to_python(LDAPSchemaExtensionItem **extensions)
     for (e = extensions; *e !=0; e++) {
       item_tuple = PyTuple_New(2);
       PyTuple_SetItem(item_tuple, 0, 
-		      PyString_FromString((*e)->lsei_name));
+		      PyUnicode_FromString((*e)->lsei_name));
       PyTuple_SetItem(item_tuple, 1, 
 		      c_string_array_to_python((*e)->lsei_values));
       PyList_SetItem(py_list, count, item_tuple);
@@ -89,7 +89,7 @@ l_ldap_str2objectclass(PyObject* self, PyObject *args)
 	return NULL;
   o = ldap_str2objectclass( oc_string, &ret, &errp, flag);
   if (ret) {
-    py_ret = PyInt_FromLong(ret);
+    py_ret = PyLong_FromLong(ret);
     return py_ret;
   }
 
@@ -98,16 +98,16 @@ l_ldap_str2objectclass(PyObject* self, PyObject *args)
   oc_at_oids_must = c_string_array_to_python(o->oc_at_oids_must);
   oc_at_oids_may  = c_string_array_to_python(o->oc_at_oids_may);
   py_ret = PyList_New(9);
-  PyList_SetItem(py_ret, 0, PyString_FromString(o->oc_oid));
+  PyList_SetItem(py_ret, 0, PyUnicode_FromString(o->oc_oid));
   PyList_SetItem(py_ret, 1, oc_names);
   if (o->oc_desc) {
-    PyList_SetItem(py_ret, 2, PyString_FromString(o->oc_desc)); 
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(o->oc_desc)); 
   } else {
-    PyList_SetItem(py_ret, 2, PyString_FromString(""));
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(""));
   }
-  PyList_SetItem(py_ret, 3, PyInt_FromLong(o->oc_obsolete));
+  PyList_SetItem(py_ret, 3, PyLong_FromLong(o->oc_obsolete));
   PyList_SetItem(py_ret, 4, oc_sup_oids);
-  PyList_SetItem(py_ret, 5, PyInt_FromLong(o->oc_kind));
+  PyList_SetItem(py_ret, 5, PyLong_FromLong(o->oc_kind));
   PyList_SetItem(py_ret, 6, oc_at_oids_must);
   PyList_SetItem(py_ret, 7, oc_at_oids_may);
 
@@ -136,50 +136,50 @@ l_ldap_str2attributetype(PyObject* self, PyObject *args)
     return NULL;
   a = ldap_str2attributetype( at_string, &ret, &errp, flag);
   if (ret) {
-    py_ret = PyInt_FromLong(ret);
+    py_ret = PyLong_FromLong(ret);
     return py_ret;
   }
   
   py_ret = PyList_New(15);
-  PyList_SetItem(py_ret, 0, PyString_FromString(a->at_oid));
+  PyList_SetItem(py_ret, 0, PyUnicode_FromString(a->at_oid));
   at_names = c_string_array_to_python(a->at_names);
   PyList_SetItem(py_ret, 1, at_names);
   if (a->at_desc) {
-    PyList_SetItem(py_ret, 2, PyString_FromString(a->at_desc)); 
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(a->at_desc)); 
   } else {
-    PyList_SetItem(py_ret, 2, PyString_FromString(""));
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(""));
   }
-  PyList_SetItem(py_ret, 3, PyInt_FromLong(a->at_obsolete));
+  PyList_SetItem(py_ret, 3, PyLong_FromLong(a->at_obsolete));
   if (a->at_sup_oid) {
-    PyList_SetItem(py_ret, 4, PyString_FromString(a->at_sup_oid)); 
+    PyList_SetItem(py_ret, 4, PyUnicode_FromString(a->at_sup_oid)); 
   } else {
-    PyList_SetItem(py_ret, 4, PyString_FromString(""));
+    PyList_SetItem(py_ret, 4, PyUnicode_FromString(""));
   }
   if (a->at_equality_oid) {
-    PyList_SetItem(py_ret, 5, PyString_FromString(a->at_equality_oid)); 
+    PyList_SetItem(py_ret, 5, PyUnicode_FromString(a->at_equality_oid)); 
   } else {
-    PyList_SetItem(py_ret, 5, PyString_FromString(""));
+    PyList_SetItem(py_ret, 5, PyUnicode_FromString(""));
   }
   if (a->at_ordering_oid) {
-    PyList_SetItem(py_ret, 6, PyString_FromString(a->at_ordering_oid)); 
+    PyList_SetItem(py_ret, 6, PyUnicode_FromString(a->at_ordering_oid)); 
   } else {
-    PyList_SetItem(py_ret, 6, PyString_FromString(""));
+    PyList_SetItem(py_ret, 6, PyUnicode_FromString(""));
   }
   if (a->at_substr_oid) {
-    PyList_SetItem(py_ret, 7, PyString_FromString(a->at_substr_oid)); 
+    PyList_SetItem(py_ret, 7, PyUnicode_FromString(a->at_substr_oid)); 
   } else {
-    PyList_SetItem(py_ret, 7, PyString_FromString(""));
+    PyList_SetItem(py_ret, 7, PyUnicode_FromString(""));
   }
   if (a->at_syntax_oid) {
-    PyList_SetItem(py_ret, 8, PyString_FromString(a->at_syntax_oid)); 
+    PyList_SetItem(py_ret, 8, PyUnicode_FromString(a->at_syntax_oid)); 
   } else {
-    PyList_SetItem(py_ret, 8, PyString_FromString(""));
+    PyList_SetItem(py_ret, 8, PyUnicode_FromString(""));
   }
-  PyList_SetItem(py_ret, 9, PyInt_FromLong(a->at_syntax_len));
-  PyList_SetItem(py_ret,10, PyInt_FromLong(a->at_single_value));
-  PyList_SetItem(py_ret,11, PyInt_FromLong(a->at_collective));
-  PyList_SetItem(py_ret,12, PyInt_FromLong(a->at_no_user_mod));
-  PyList_SetItem(py_ret,13, PyInt_FromLong(a->at_usage));
+  PyList_SetItem(py_ret, 9, PyLong_FromLong(a->at_syntax_len));
+  PyList_SetItem(py_ret,10, PyLong_FromLong(a->at_single_value));
+  PyList_SetItem(py_ret,11, PyLong_FromLong(a->at_collective));
+  PyList_SetItem(py_ret,12, PyLong_FromLong(a->at_no_user_mod));
+  PyList_SetItem(py_ret,13, PyLong_FromLong(a->at_usage));
   
   PyList_SetItem(py_ret, 14, 
 		 schema_extension_to_python(a->at_extensions));
@@ -204,17 +204,17 @@ l_ldap_str2syntax(PyObject* self, PyObject *args)
     return NULL;
   s = ldap_str2syntax(syn_string, &ret, &errp, flag);
   if (ret) {
-    py_ret = PyInt_FromLong(ret);
+    py_ret = PyLong_FromLong(ret);
     return py_ret;
   }
   py_ret = PyList_New(4);
-  PyList_SetItem(py_ret, 0, PyString_FromString(s->syn_oid));
+  PyList_SetItem(py_ret, 0, PyUnicode_FromString(s->syn_oid));
   syn_names = c_string_array_to_python(s->syn_names);
   PyList_SetItem(py_ret, 1, syn_names);
   if (s->syn_desc) {
-    PyList_SetItem(py_ret, 2, PyString_FromString(s->syn_desc)); 
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(s->syn_desc)); 
   } else {
-    PyList_SetItem(py_ret, 2, PyString_FromString(""));
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(""));
   }
   PyList_SetItem(py_ret, 3, 
 		 schema_extension_to_python(s->syn_extensions));
@@ -238,23 +238,23 @@ l_ldap_str2matchingrule(PyObject* self, PyObject *args)
     return NULL;
   m = ldap_str2matchingrule(mr_string, &ret, &errp, flag);
   if (ret) {
-    py_ret = PyInt_FromLong(ret);
+    py_ret = PyLong_FromLong(ret);
     return py_ret;
   }
   py_ret = PyList_New(6);
-  PyList_SetItem(py_ret, 0, PyString_FromString(m->mr_oid));
+  PyList_SetItem(py_ret, 0, PyUnicode_FromString(m->mr_oid));
   mr_names = c_string_array_to_python(m->mr_names);
   PyList_SetItem(py_ret, 1, mr_names);
   if (m->mr_desc) {
-    PyList_SetItem(py_ret, 2, PyString_FromString(m->mr_desc)); 
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(m->mr_desc)); 
   } else {
-    PyList_SetItem(py_ret, 2, PyString_FromString(""));
+    PyList_SetItem(py_ret, 2, PyUnicode_FromString(""));
   }
-  PyList_SetItem(py_ret, 3, PyInt_FromLong(m->mr_obsolete));
+  PyList_SetItem(py_ret, 3, PyLong_FromLong(m->mr_obsolete));
   if (m->mr_syntax_oid) {
-    PyList_SetItem(py_ret, 4, PyString_FromString(m->mr_syntax_oid)); 
+    PyList_SetItem(py_ret, 4, PyUnicode_FromString(m->mr_syntax_oid)); 
   } else {
-    PyList_SetItem(py_ret, 4, PyString_FromString(""));
+    PyList_SetItem(py_ret, 4, PyUnicode_FromString(""));
   }  
   PyList_SetItem(py_ret, 5, 
 		 schema_extension_to_python(m->mr_extensions));

--- a/Modules/version.c
+++ b/Modules/version.c
@@ -14,7 +14,7 @@ LDAPinit_version( PyObject* d )
 {
 	PyObject *version;
 
-	version = PyString_FromString(version_str);
+	version = PyUnicode_FromString(version_str);
 	PyDict_SetItemString( d, "__version__", version );
 	Py_DECREF(version);
 }

--- a/Tests/search.py
+++ b/Tests/search.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import sys,pprint,ldap
 
 from ldap.ldapobject import LDAPObject

--- a/Tests/slapd.py
+++ b/Tests/slapd.py
@@ -154,7 +154,8 @@ class Slapd:
             self._log.debug("deleting existing %s", path)
             os.remove(path)
         self._log.debug("writing config to %s", path)
-        file(path, "w").writelines([line + "\n" for line in self._config])
+        with open(path, 'w') as f:
+            f.writelines([line + "\n" for line in self._config])
         return path
 
     def start(self):

--- a/Tests/slapd.py
+++ b/Tests/slapd.py
@@ -4,6 +4,8 @@ Utilities for starting up a test slapd server
 and talking to it with ldapsearch/ldapadd.
 """
 
+from __future__ import unicode_literals
+
 import sys, os, socket, time, subprocess, logging
 
 _log = logging.getLogger("slapd")

--- a/Tests/slapd.py
+++ b/Tests/slapd.py
@@ -272,7 +272,7 @@ class Slapd:
                 "-w", self.get_root_password(),
                 "-H", self.get_url()] + extra_args,
                 stdin = subprocess.PIPE, stdout=subprocess.PIPE)
-        p.communicate(ldif)
+        p.communicate(ldif.encode('utf-8'))
         if p.wait() != 0:
             raise RuntimeError("ldapadd process failed")
 

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -46,30 +46,30 @@ class TestLdapCExtension(unittest.TestCase):
         return l
 
     def assertNotNone(self, expr, msg=None):
-        self.failIf(expr is None, msg or repr(expr))
+        self.assertFalse(expr is None, msg or repr(expr))
     def assertNone(self, expr, msg=None):
-        self.failIf(expr is not None, msg or repr(expr))
+        self.assertFalse(expr is not None, msg or repr(expr))
 
     # Test for the existence of a whole bunch of constants
     # that the C module is supposed to export
     def test_constants(self):
-        self.assertEquals(_ldap.PORT, 389)
-        self.assertEquals(_ldap.VERSION1, 1)
-        self.assertEquals(_ldap.VERSION2, 2)
-        self.assertEquals(_ldap.VERSION3, 3)
+        self.assertEqual(_ldap.PORT, 389)
+        self.assertEqual(_ldap.VERSION1, 1)
+        self.assertEqual(_ldap.VERSION2, 2)
+        self.assertEqual(_ldap.VERSION3, 3)
 
         # constants for result4()
-        self.assertEquals(_ldap.RES_BIND, 0x61)
-        self.assertEquals(_ldap.RES_SEARCH_ENTRY, 0x64)
-        self.assertEquals(_ldap.RES_SEARCH_RESULT, 0x65)
-        self.assertEquals(_ldap.RES_MODIFY, 0x67)
-        self.assertEquals(_ldap.RES_ADD, 0x69)
-        self.assertEquals(_ldap.RES_DELETE, 0x6b)
-        self.assertEquals(_ldap.RES_MODRDN, 0x6d)
-        self.assertEquals(_ldap.RES_COMPARE, 0x6f)
-        self.assertEquals(_ldap.RES_SEARCH_REFERENCE, 0x73) # v3
-        self.assertEquals(_ldap.RES_EXTENDED, 0x78)         # v3
-        #self.assertEquals(_ldap.RES_INTERMEDIATE, 0x79)     # v3
+        self.assertEqual(_ldap.RES_BIND, 0x61)
+        self.assertEqual(_ldap.RES_SEARCH_ENTRY, 0x64)
+        self.assertEqual(_ldap.RES_SEARCH_RESULT, 0x65)
+        self.assertEqual(_ldap.RES_MODIFY, 0x67)
+        self.assertEqual(_ldap.RES_ADD, 0x69)
+        self.assertEqual(_ldap.RES_DELETE, 0x6b)
+        self.assertEqual(_ldap.RES_MODRDN, 0x6d)
+        self.assertEqual(_ldap.RES_COMPARE, 0x6f)
+        self.assertEqual(_ldap.RES_SEARCH_REFERENCE, 0x73) # v3
+        self.assertEqual(_ldap.RES_EXTENDED, 0x78)         # v3
+        #self.assertEqual(_ldap.RES_INTERMEDIATE, 0x79)     # v3
         self.assertNotNone(_ldap.RES_ANY)
         self.assertNotNone(_ldap.RES_UNSOLICITED)
 
@@ -157,16 +157,16 @@ class TestLdapCExtension(unittest.TestCase):
         m = l.simple_bind("", "")
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertTrue(result, _ldap.RES_BIND)
-        self.assertEquals(msgid, m)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(ctrls, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(ctrls, [])
 
         # see if we can get the rootdse while we're here
         m = l.search_ext("", _ldap.SCOPE_BASE, '(objectClass=*)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(pmsg[0][0], "") # rootDSE has no dn
-        self.assertEquals(msgid, m)
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(pmsg[0][0], "") # rootDSE has no dn
+        self.assertEqual(msgid, m)
         self.assertIn('objectClass', pmsg[0][1])
 
     def test_unbind(self):
@@ -186,21 +186,21 @@ class TestLdapCExtension(unittest.TestCase):
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ONE, self.timeout)
 
         # Expect to get just one object
-        self.assertEquals(result, _ldap.RES_SEARCH_ENTRY)
-        self.assertEquals(len(pmsg), 1)
-        self.assertEquals(len(pmsg[0]), 2)
-        self.assertEquals(pmsg[0][0], self.base)
-        self.assertEquals(pmsg[0][0], self.base)
+        self.assertEqual(result, _ldap.RES_SEARCH_ENTRY)
+        self.assertEqual(len(pmsg), 1)
+        self.assertEqual(len(pmsg[0]), 2)
+        self.assertEqual(pmsg[0][0], self.base)
+        self.assertEqual(pmsg[0][0], self.base)
         self.assertTrue(b'dcObject' in pmsg[0][1]['objectClass'])
         self.assertTrue(b'organization' in pmsg[0][1]['objectClass'])
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ONE, self.timeout)
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
     def test_abandon(self):
         l = self._init()
@@ -224,10 +224,10 @@ class TestLdapCExtension(unittest.TestCase):
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # Expect to get some objects
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
         self.assertTrue(len(pmsg) >= 2)
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
     def test_add(self):
         l = self._init()
@@ -239,20 +239,20 @@ class TestLdapCExtension(unittest.TestCase):
             ])
 
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_ADD)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
         # search for it back
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=Foo)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # Expect to get the objects
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(len(pmsg), 1)
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(len(pmsg), 1)
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
         self.assertEqual(pmsg[0], ('cn=Foo,'+self.base,
                 { 'objectClass': [b'organizationalRole'],
@@ -271,7 +271,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('userPassword', b'the_password'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         # try a false compare
         m = l.compare_ext(dn, "userPassword", "bad_string")
@@ -324,14 +324,14 @@ class TestLdapCExtension(unittest.TestCase):
                ('cn', b'Deleteme'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         m = l.delete_ext(dn)
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_DELETE)
-        self.assertEquals(msgid, m)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_DELETE)
+        self.assertEqual(msgid, m)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(ctrls, [])
 
     def test_modify_no_such_object(self):
         l = self._init()
@@ -372,28 +372,28 @@ class TestLdapCExtension(unittest.TestCase):
                ('description', b'a description'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         m = l.modify_ext(dn, [
                 (_ldap.MOD_ADD, 'description', [b'b desc', b'c desc']),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_MODIFY)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_MODIFY)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
         # search for it back
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=AddToMe)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # Expect to get the objects
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(len(pmsg), 1)
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(len(pmsg), 1)
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
-        self.assertEquals(pmsg[0][0], dn)
+        self.assertEqual(pmsg[0][0], dn)
         d = list(pmsg[0][1]['description'])
         d.sort()
         self.assertEqual(d, [b'a description', b'b desc', b'c desc'])
@@ -406,33 +406,33 @@ class TestLdapCExtension(unittest.TestCase):
                ('cn', b'RenameMe'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         # do the rename with same parent
         m = l.rename(dn, "cn=IAmRenamed")
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_MODRDN)
-        self.assertEquals(msgid, m)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_MODRDN)
+        self.assertEqual(msgid, m)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(ctrls, [])
 
         # make sure the old one is gone
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=RenameMe)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(len(pmsg), 0) # expect no results
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(len(pmsg), 0) # expect no results
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
         # check that the new one looks right
         dn2 = "cn=IAmRenamed,"+self.base
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
-        self.assertEquals(len(pmsg), 1)
-        self.assertEquals(pmsg[0][0], dn2)
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
+        self.assertEqual(len(pmsg), 1)
+        self.assertEqual(pmsg[0][0], dn2)
         self.assertEqual(pmsg[0][1]['cn'], [b'IAmRenamed'])
 
         # create the container
@@ -442,7 +442,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('ou', b'RenameContainer'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         # WORKAROUND bug in slapd. (Without an existing child, 
         # renames into a container object do not work for the ldif backend,
@@ -453,7 +453,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('cn', b'Bogus'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         # now rename from dn2 to the conater
         dn3 = "cn=IAmRenamedAgain," + containerDn
@@ -461,18 +461,18 @@ class TestLdapCExtension(unittest.TestCase):
         # Now try renaming dn2 across container (simultaneous name change)
         m = l.rename(dn2, "cn=IAmRenamedAgain", containerDn)
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_MODRDN)
-        self.assertEquals(msgid, m)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_MODRDN)
+        self.assertEqual(msgid, m)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(ctrls, [])
 
         # make sure dn2 is gone
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(len(pmsg), 0) # expect no results
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(len(pmsg), 0) # expect no results
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
 
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(objectClass=*)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
@@ -480,24 +480,24 @@ class TestLdapCExtension(unittest.TestCase):
         # make sure dn3 is there
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamedAgain)')
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
-        self.assertEquals(msgid, m)
-        self.assertEquals(ctrls, [])
-        self.assertEquals(len(pmsg), 1)
-        self.assertEquals(pmsg[0][0], dn3)
+        self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
+        self.assertEqual(msgid, m)
+        self.assertEqual(ctrls, [])
+        self.assertEqual(len(pmsg), 1)
+        self.assertEqual(pmsg[0][0], dn3)
         self.assertEqual(pmsg[0][1]['cn'], [b'IAmRenamedAgain'])
 
 
     def test_whoami(self):
         l = self._init()
         r = l.whoami_s()
-        self.assertEquals("dn:" + self.server.get_root_dn(), r)
+        self.assertEqual("dn:" + self.server.get_root_dn(), r)
 
     def test_whoami_unbound(self):
         l = self._init(bind=False)
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
         r = l.whoami_s()
-        self.assertEquals("", r)
+        self.assertEqual("", r)
 
     def test_whoami_anonymous(self):
         l = self._init(bind=False)
@@ -509,7 +509,7 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertTrue(result, _ldap.RES_BIND)
 
         r = l.whoami_s()
-        self.assertEquals("", r)
+        self.assertEqual("", r)
 
     def test_passwd(self):
         l = self._init()
@@ -523,7 +523,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('userPassword', b'initial'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(result, _ldap.RES_ADD)
+        self.assertEqual(result, _ldap.RES_ADD)
 
         # try changing password with a wrong old-pw
         m = l.passwd(dn, "bogus", "ignored")
@@ -536,10 +536,10 @@ class TestLdapCExtension(unittest.TestCase):
         # try changing password with a correct old-pw
         m = l.passwd(dn, "initial", "changed")
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertEquals(msgid, m)
-        self.assertEquals(pmsg, [])
-        self.assertEquals(result, _ldap.RES_EXTENDED)
-        self.assertEquals(ctrls, [])
+        self.assertEqual(msgid, m)
+        self.assertEqual(pmsg, [])
+        self.assertEqual(result, _ldap.RES_EXTENDED)
+        self.assertEqual(ctrls, [])
 
     def test_options(self):
         oldval = _ldap.get_option(_ldap.OPT_PROTOCOL_VERSION)
@@ -552,10 +552,10 @@ class TestLdapCExtension(unittest.TestCase):
 
             _ldap.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION2)
             v = _ldap.get_option(_ldap.OPT_PROTOCOL_VERSION)
-            self.assertEquals(v, _ldap.VERSION2)
+            self.assertEqual(v, _ldap.VERSION2)
             _ldap.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
             v = _ldap.get_option(_ldap.OPT_PROTOCOL_VERSION)
-            self.assertEquals(v, _ldap.VERSION3)
+            self.assertEqual(v, _ldap.VERSION3)
         finally:
             _ldap.set_option(_ldap.OPT_PROTOCOL_VERSION, oldval)
 
@@ -565,11 +565,11 @@ class TestLdapCExtension(unittest.TestCase):
 
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION2)
         v = l.get_option(_ldap.OPT_PROTOCOL_VERSION)
-        self.assertEquals(v, _ldap.VERSION2)
+        self.assertEqual(v, _ldap.VERSION2)
 
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
         v = l.get_option(_ldap.OPT_PROTOCOL_VERSION)
-        self.assertEquals(v, _ldap.VERSION3)
+        self.assertEqual(v, _ldap.VERSION3)
 
         # Try setting options that will yield a known error.
         try:

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -165,7 +165,7 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(pmsg[0][0], "") # rootDSE has no dn
         self.assertEquals(msgid, m)
-        self.assertTrue(pmsg[0][1].has_key('objectClass'))
+        self.assertIn('objectClass', pmsg[0][1])
 
     def test_unbind(self):
         l = self._init()

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -211,7 +211,7 @@ class TestLdapCExtension(unittest.TestCase):
         got_timeout = False
         try:
             r = l.result4(m, _ldap.MSG_ALL, 0.3)  # (timeout /could/ be longer)
-        except _ldap.TIMEOUT, e:
+        except _ldap.TIMEOUT as e:
             got_timeout = True
         self.assertTrue(got_timeout)
 

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 
 import unittest, slapd
 import _ldap

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -39,7 +39,7 @@ class TestLdapCExtension(unittest.TestCase):
             # Perform a simple bind
             l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
             m = l.simple_bind(server.get_root_dn(), server.get_root_password())
-            result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ONE, self.timeout)
+            result, _pmsg, _msgid, _ctrls = l.result4(m, _ldap.MSG_ONE, self.timeout)
             self.assertTrue(result, _ldap.RES_BIND)
         return l
 
@@ -56,7 +56,7 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(_ldap.VERSION2, 2)
         self.assertEquals(_ldap.VERSION3, 3)
 
-        # constants for result3()
+        # constants for result4()
         self.assertEquals(_ldap.RES_BIND, 0x61)
         self.assertEquals(_ldap.RES_SEARCH_ENTRY, 0x64)
         self.assertEquals(_ldap.RES_SEARCH_RESULT, 0x65)
@@ -84,7 +84,7 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertNotNone(_ldap.MOD_INCREMENT)
         self.assertNotNone(_ldap.MOD_BVALUES)
 
-        # for result3()
+        # for result4()
         self.assertNotNone(_ldap.MSG_ONE)
         self.assertNotNone(_ldap.MSG_ALL)
         self.assertNotNone(_ldap.MSG_RECEIVED)
@@ -143,10 +143,6 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertNotNone(_ldap.AVA_BINARY)
         self.assertNotNone(_ldap.AVA_NONPRINTABLE)
 
-        # these two constants are pointless? XXX
-        self.assertEquals(_ldap.LDAP_OPT_ON, 1) 
-        self.assertEquals(_ldap.LDAP_OPT_OFF, 0)
-
         # these constants useless after ldap_url_parse() was dropped XXX
         self.assertNotNone(_ldap.URL_ERR_BADSCOPE)
         self.assertNotNone(_ldap.URL_ERR_MEM)
@@ -157,7 +153,7 @@ class TestLdapCExtension(unittest.TestCase):
     def test_simple_anonymous_bind(self):
         l = self._init(bind=False)
         m = l.simple_bind("", "")
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertTrue(result, _ldap.RES_BIND)
         self.assertEquals(msgid, m)
         self.assertEquals(pmsg, [])
@@ -165,7 +161,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         # see if we can get the rootdse while we're here
         m = l.search_ext("", _ldap.SCOPE_BASE, '(objectClass=*)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(pmsg[0][0], "") # rootDSE has no dn
         self.assertEquals(msgid, m)
@@ -185,7 +181,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, 
                 '(objectClass=dcObject)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ONE, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ONE, self.timeout)
 
         # Expect to get just one object
         self.assertEquals(result, _ldap.RES_SEARCH_ENTRY)
@@ -198,7 +194,7 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(msgid, m)
         self.assertEquals(ctrls, [])
 
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ONE, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ONE, self.timeout)
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(pmsg, [])
         self.assertEquals(msgid, m)
@@ -214,7 +210,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         got_timeout = False
         try:
-            r = l.result3(m, _ldap.MSG_ALL, 0.3)  # (timeout /could/ be longer)
+            r = l.result4(m, _ldap.MSG_ALL, 0.3)  # (timeout /could/ be longer)
         except _ldap.TIMEOUT, e:
             got_timeout = True
         self.assertTrue(got_timeout)
@@ -223,7 +219,7 @@ class TestLdapCExtension(unittest.TestCase):
         l = self._init()
 
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(objectClass=*)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # Expect to get some objects
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
@@ -240,7 +236,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('description', 'testing'),
             ])
 
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
         self.assertEquals(pmsg, [])
         self.assertEquals(msgid, m)
@@ -248,7 +244,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         # search for it back
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=Foo)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # Expect to get the objects
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
@@ -272,14 +268,14 @@ class TestLdapCExtension(unittest.TestCase):
                ('cn', 'CompareTest'),
                ('userPassword', 'the_password'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         # try a false compare
         m = l.compare_ext(dn, "userPassword", "bad_string")
         compared_false = False
         try:
-            r = l.result3(m, _ldap.MSG_ALL, self.timeout)
+            r = l.result4(m, _ldap.MSG_ALL, self.timeout)
             self.fail(repr(r))
         except _ldap.COMPARE_FALSE:
             compared_false = True
@@ -289,7 +285,7 @@ class TestLdapCExtension(unittest.TestCase):
         m = l.compare_ext(dn, "userPassword", "the_password")
         compared_true = False
         try:
-            r = l.result3(m, _ldap.MSG_ALL, self.timeout)
+            r = l.result4(m, _ldap.MSG_ALL, self.timeout)
             self.fail(repr(r))
         except _ldap.COMPARE_TRUE:
             compared_true = True
@@ -298,7 +294,7 @@ class TestLdapCExtension(unittest.TestCase):
         m = l.compare_ext(dn, "badAttribute", "ignoreme")
         raised_error = False
         try:
-            r = l.result3(m, _ldap.MSG_ALL, self.timeout)
+            r = l.result4(m, _ldap.MSG_ALL, self.timeout)
             self.fail(repr(r))
         except _ldap.error:
             raised_error = True
@@ -311,7 +307,7 @@ class TestLdapCExtension(unittest.TestCase):
         not_found = False
         m = l.delete_ext("cn=DoesNotExist,"+self.base)
         try:
-            r = l.result3(m, _ldap.MSG_ALL, self.timeout)
+            r = l.result4(m, _ldap.MSG_ALL, self.timeout)
             self.fail(r)
         except _ldap.NO_SUCH_OBJECT:
             not_found = True
@@ -325,11 +321,11 @@ class TestLdapCExtension(unittest.TestCase):
                ('objectClass','organizationalRole'), 
                ('cn', 'Deleteme'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         m = l.delete_ext(dn)
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_DELETE)
         self.assertEquals(msgid, m)
         self.assertEquals(pmsg, [])
@@ -344,7 +340,7 @@ class TestLdapCExtension(unittest.TestCase):
                 (_ldap.MOD_ADD, 'description', ['blah']),
             ])
         try:
-            r = l.result3(m, _ldap.MSG_ALL, self.timeout)
+            r = l.result4(m, _ldap.MSG_ALL, self.timeout)
             self.fail(r)
         except _ldap.NO_SUCH_OBJECT:
             not_found = True
@@ -360,7 +356,7 @@ class TestLdapCExtension(unittest.TestCase):
                 (_ldap.MOD_ADD, 'description', []),
             ])
         self.assertTrue(isinstance(m, int))
-        r = l.result3(m, _ldap.MSG_ALL, self.timeout) # what should happen??
+        r = l.result4(m, _ldap.MSG_ALL, self.timeout) # what should happen??
         self.fail(r)
 
     def test_modify(self):
@@ -373,13 +369,13 @@ class TestLdapCExtension(unittest.TestCase):
                ('sn', 'Modify'),
                ('description', 'a description'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         m = l.modify_ext(dn, [
                 (_ldap.MOD_ADD, 'description', ['b desc', 'c desc']),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_MODIFY)
         self.assertEquals(pmsg, [])
         self.assertEquals(msgid, m)
@@ -387,7 +383,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         # search for it back
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=AddToMe)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # Expect to get the objects
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
@@ -407,12 +403,12 @@ class TestLdapCExtension(unittest.TestCase):
                ('objectClass','organizationalRole'), 
                ('cn', 'RenameMe'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         # do the rename with same parent
         m = l.rename(dn, "cn=IAmRenamed")
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_MODRDN)
         self.assertEquals(msgid, m)
         self.assertEquals(pmsg, [])
@@ -420,7 +416,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         # make sure the old one is gone
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=RenameMe)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(len(pmsg), 0) # expect no results
         self.assertEquals(msgid, m)
@@ -429,7 +425,7 @@ class TestLdapCExtension(unittest.TestCase):
         # check that the new one looks right
         dn2 = "cn=IAmRenamed,"+self.base
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(msgid, m)
         self.assertEquals(ctrls, [])
@@ -443,7 +439,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('objectClass','organizationalUnit'), 
                ('ou', 'RenameContainer'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         # WORKAROUND bug in slapd. (Without an existing child, 
@@ -454,7 +450,7 @@ class TestLdapCExtension(unittest.TestCase):
                ('objectClass','organizationalRole'), 
                ('cn', 'Bogus'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         # now rename from dn2 to the conater
@@ -462,7 +458,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         # Now try renaming dn2 across container (simultaneous name change)
         m = l.rename(dn2, "cn=IAmRenamedAgain", containerDn)
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_MODRDN)
         self.assertEquals(msgid, m)
         self.assertEquals(pmsg, [])
@@ -470,18 +466,18 @@ class TestLdapCExtension(unittest.TestCase):
 
         # make sure dn2 is gone
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(len(pmsg), 0) # expect no results
         self.assertEquals(msgid, m)
         self.assertEquals(ctrls, [])
 
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(objectClass=*)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # make sure dn3 is there
         m = l.search_ext(self.base, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamedAgain)')
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_SEARCH_RESULT)
         self.assertEquals(msgid, m)
         self.assertEquals(ctrls, [])
@@ -507,7 +503,7 @@ class TestLdapCExtension(unittest.TestCase):
 
         # Anonymous bind
         m = l.simple_bind("", "")
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertTrue(result, _ldap.RES_BIND)
 
         r = l.whoami_s()
@@ -524,20 +520,20 @@ class TestLdapCExtension(unittest.TestCase):
                ('cn', 'PasswordTest'),
                ('userPassword', 'initial'),
             ])
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         # try changing password with a wrong old-pw
         m = l.passwd(dn, "bogus", "ignored")
         try:
-            r = l.result3(m, _ldap.MSG_ALL, self.timeout)
+            r = l.result4(m, _ldap.MSG_ALL, self.timeout)
             self.fail("expected UNWILLING_TO_PERFORM")
         except _ldap.UNWILLING_TO_PERFORM:
             pass
 
         # try changing password with a correct old-pw
         m = l.passwd(dn, "initial", "changed")
-        result,pmsg,msgid,ctrls = l.result3(m, _ldap.MSG_ALL, self.timeout)
+        result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(msgid, m)
         self.assertEquals(pmsg, [])
         self.assertEquals(result, _ldap.RES_EXTENDED)

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -191,8 +191,8 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(len(pmsg[0]), 2)
         self.assertEquals(pmsg[0][0], self.base)
         self.assertEquals(pmsg[0][0], self.base)
-        self.assertTrue('dcObject' in pmsg[0][1]['objectClass'])
-        self.assertTrue('organization' in pmsg[0][1]['objectClass'])
+        self.assertTrue(b'dcObject' in pmsg[0][1]['objectClass'])
+        self.assertTrue(b'organization' in pmsg[0][1]['objectClass'])
         self.assertEquals(msgid, m)
         self.assertEquals(ctrls, [])
 
@@ -233,9 +233,9 @@ class TestLdapCExtension(unittest.TestCase):
         l = self._init()
 
         m = l.add_ext("cn=Foo," + self.base, [
-               ('objectClass','organizationalRole'), 
-               ('cn', 'Foo'),
-               ('description', 'testing'),
+               ('objectClass', b'organizationalRole'),
+               ('cn', b'Foo'),
+               ('description', b'testing'),
             ])
 
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
@@ -254,10 +254,10 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(msgid, m)
         self.assertEquals(ctrls, [])
 
-        self.assertEquals(pmsg[0], ('cn=Foo,'+self.base,
-                { 'objectClass': ['organizationalRole'],
-                  'cn': ['Foo'],
-                  'description': ['testing'] }))
+        self.assertEqual(pmsg[0], ('cn=Foo,'+self.base,
+                { 'objectClass': [b'organizationalRole'],
+                  'cn': [b'Foo'],
+                  'description': [b'testing'] }))
 
     def test_compare(self):
         l = self._init()
@@ -265,10 +265,10 @@ class TestLdapCExtension(unittest.TestCase):
         # first, add an object with a field we can compare on
         dn = "cn=CompareTest," + self.base
         m = l.add_ext(dn, [
-               ('objectClass','person'), 
-               ('sn', 'CompareTest'),
-               ('cn', 'CompareTest'),
-               ('userPassword', 'the_password'),
+               ('objectClass', b'person'),
+               ('sn', b'CompareTest'),
+               ('cn', b'CompareTest'),
+               ('userPassword', b'the_password'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
@@ -320,8 +320,8 @@ class TestLdapCExtension(unittest.TestCase):
         # first, add an object we will delete
         dn = "cn=Deleteme,"+self.base
         m = l.add_ext(dn, [
-               ('objectClass','organizationalRole'), 
-               ('cn', 'Deleteme'),
+               ('objectClass', b'organizationalRole'),
+               ('cn', b'Deleteme'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
@@ -339,7 +339,7 @@ class TestLdapCExtension(unittest.TestCase):
         # try deleting an object that doesn't exist
         not_found = False
         m = l.modify_ext("cn=DoesNotExist,"+self.base, [
-                (_ldap.MOD_ADD, 'description', ['blah']),
+                (_ldap.MOD_ADD, 'description', [b'blah']),
             ])
         try:
             r = l.result4(m, _ldap.MSG_ALL, self.timeout)
@@ -366,16 +366,16 @@ class TestLdapCExtension(unittest.TestCase):
         # first, add an object we will delete
         dn = "cn=AddToMe,"+self.base
         m = l.add_ext(dn, [
-               ('objectClass','person'), 
-               ('cn', 'AddToMe'),
-               ('sn', 'Modify'),
-               ('description', 'a description'),
+               ('objectClass', b'person'),
+               ('cn', b'AddToMe'),
+               ('sn', b'Modify'),
+               ('description', b'a description'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
 
         m = l.modify_ext(dn, [
-                (_ldap.MOD_ADD, 'description', ['b desc', 'c desc']),
+                (_ldap.MOD_ADD, 'description', [b'b desc', b'c desc']),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_MODIFY)
@@ -396,14 +396,14 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(pmsg[0][0], dn)
         d = list(pmsg[0][1]['description'])
         d.sort()
-        self.assertEquals(d, ['a description', 'b desc', 'c desc'])
+        self.assertEqual(d, [b'a description', b'b desc', b'c desc'])
 
     def test_rename(self):
         l = self._init()
         dn = "cn=RenameMe,"+self.base
         m = l.add_ext(dn, [
-               ('objectClass','organizationalRole'), 
-               ('cn', 'RenameMe'),
+               ('objectClass', b'organizationalRole'),
+               ('cn', b'RenameMe'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
@@ -433,13 +433,13 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(ctrls, [])
         self.assertEquals(len(pmsg), 1)
         self.assertEquals(pmsg[0][0], dn2)
-        self.assertEquals(pmsg[0][1]['cn'], ['IAmRenamed'])
+        self.assertEqual(pmsg[0][1]['cn'], [b'IAmRenamed'])
 
         # create the container
         containerDn = "ou=RenameContainer,"+self.base
         m = l.add_ext(containerDn, [
-               ('objectClass','organizationalUnit'), 
-               ('ou', 'RenameContainer'),
+               ('objectClass', b'organizationalUnit'),
+               ('ou', b'RenameContainer'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
@@ -449,8 +449,8 @@ class TestLdapCExtension(unittest.TestCase):
         # the renamed object appears to be deleted, not moved.)
         # see http://www.openldap.org/its/index.cgi/Software%20Bugs?id=5408
         m = l.add_ext("cn=Bogus," + containerDn, [
-               ('objectClass','organizationalRole'), 
-               ('cn', 'Bogus'),
+               ('objectClass', b'organizationalRole'),
+               ('cn', b'Bogus'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)
@@ -485,7 +485,7 @@ class TestLdapCExtension(unittest.TestCase):
         self.assertEquals(ctrls, [])
         self.assertEquals(len(pmsg), 1)
         self.assertEquals(pmsg[0][0], dn3)
-        self.assertEquals(pmsg[0][1]['cn'], ['IAmRenamedAgain'])
+        self.assertEqual(pmsg[0][1]['cn'], [b'IAmRenamedAgain'])
 
 
     def test_whoami(self):
@@ -517,10 +517,10 @@ class TestLdapCExtension(unittest.TestCase):
         # first, create a user to change password on
         dn = "cn=PasswordTest," + self.base
         m = l.add_ext(dn, [
-               ('objectClass','person'), 
-               ('sn', 'PasswordTest'),
-               ('cn', 'PasswordTest'),
-               ('userPassword', 'initial'),
+               ('objectClass', b'person'),
+               ('sn', b'PasswordTest'),
+               ('cn', b'PasswordTest'),
+               ('userPassword', b'initial'),
             ])
         result,pmsg,msgid,ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEquals(result, _ldap.RES_ADD)

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -117,7 +117,7 @@ class TestLDAPUrl(unittest.TestCase):
         u = LDAPUrl("ldap:///dn=foo%3f")
         self.assertEquals(u.dn, "dn=foo?")
         u = LDAPUrl("ldap:///dn=str%c3%b6der.com")
-        self.assertEquals(u.dn, "dn=str\xc3\xb6der.com")
+        self.assertEquals(u.dn, "dn=str\xf6der.com")
 
     def test_parse_attrs(self):
         u = LDAPUrl("ldap:///?")
@@ -177,7 +177,7 @@ class TestLDAPUrl(unittest.TestCase):
         u = LDAPUrl("ldap:///???(cn=Q%3f)")
         self.assertEquals(u.filterstr, "(cn=Q?)")
         u = LDAPUrl("ldap:///???(sn=Str%c3%b6der)") # (possibly bad?)
-        self.assertEquals(u.filterstr, "(sn=Str\xc3\xb6der)")
+        self.assertEquals(u.filterstr, "(sn=Str\xf6der)")
         u = LDAPUrl("ldap:///???(sn=Str\\c3\\b6der)")
         self.assertEquals(u.filterstr, "(sn=Str\\c3\\b6der)") # (recommended)
         u = LDAPUrl("ldap:///???(cn=*\\2a*)")

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import ldap, unittest
 from ldap.compat import quote
 

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
+
 import ldap, unittest
-import urllib
+from ldap.compat import quote
 
 from ldapurl import LDAPUrl
 
@@ -26,9 +28,9 @@ class TestLDAPUrl(unittest.TestCase):
         u = MyLDAPUrl("ldap://127.0.0.1:1234/dc=example,dc=com"
             + "?attr1,attr2,attr3"
             + "?sub"
-            + "?" + urllib.quote("(objectClass=*)")
-            + "?bindname=" + urllib.quote("cn=d,c=au")
-            + ",X-BINDPW=" + urllib.quote("???")
+            + "?" + quote("(objectClass=*)")
+            + "?bindname=" + quote("cn=d,c=au")
+            + ",X-BINDPW=" + quote("???")
             + ",trace=8"
         )
         self.assertEquals(u.urlscheme, "ldap")

--- a/Tests/t_search.py
+++ b/Tests/t_search.py
@@ -54,7 +54,7 @@ class TestSearch(unittest.TestCase):
 
         result = l.search_s(base, ldap.SCOPE_SUBTREE, '(cn=Foo*)', ['*'])
         result.sort()
-        self.assertEquals(result,
+        self.assertEqual(result,
             [('cn=Foo1,'+base,
                {'cn': [b'Foo1'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo2,'+base,
@@ -72,7 +72,7 @@ class TestSearch(unittest.TestCase):
 
         result = l.search_s(base, ldap.SCOPE_ONELEVEL, '(cn=Foo*)', ['*'])
         result.sort()
-        self.assertEquals(result,
+        self.assertEqual(result,
             [('cn=Foo1,'+base,
                {'cn': [b'Foo1'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo2,'+base,

--- a/Tests/t_search.py
+++ b/Tests/t_search.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import ldap, unittest
 import slapd
 

--- a/Tests/t_search.py
+++ b/Tests/t_search.py
@@ -56,13 +56,13 @@ class TestSearch(unittest.TestCase):
         result.sort()
         self.assertEquals(result,
             [('cn=Foo1,'+base,
-               {'cn': ['Foo1'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo1'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo2,'+base,
-               {'cn': ['Foo2'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo2'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo3,'+base,
-               {'cn': ['Foo3'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo3'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo4,ou=Container,'+base,
-               {'cn': ['Foo4'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo4'], 'objectClass': [b'organizationalRole']}),
             ]
         )
 
@@ -74,11 +74,11 @@ class TestSearch(unittest.TestCase):
         result.sort()
         self.assertEquals(result,
             [('cn=Foo1,'+base,
-               {'cn': ['Foo1'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo1'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo2,'+base,
-               {'cn': ['Foo2'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo2'], 'objectClass': [b'organizationalRole']}),
              ('cn=Foo3,'+base,
-               {'cn': ['Foo3'], 'objectClass': ['organizationalRole']}),
+               {'cn': [b'Foo3'], 'objectClass': [b'organizationalRole']}),
             ]
         )
 
@@ -88,8 +88,8 @@ class TestSearch(unittest.TestCase):
 
         result = l.search_s(base, ldap.SCOPE_SUBTREE, '(cn=Foo4)', ['cn'])
         result.sort()
-        self.assertEquals(result,
-            [('cn=Foo4,ou=Container,'+base, {'cn': ['Foo4']})]
+        self.assertEqual(result,
+            [('cn=Foo4,ou=Container,'+base, {'cn': [b'Foo4']})]
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ setup(
     'dsml',
     'ldap',
     'ldap.async',
+    'ldap.compat',
     'ldap.controls',
     'ldap.controls.libldap',
     'ldap.controls.openldap',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ See http://www.python-ldap.org/ for details.
 $Id: setup.py,v 1.72 2014/03/12 20:29:23 stroeder Exp $
 """
 
+import sys,os,string,time
+
 has_setuptools = False
 try:
         from setuptools import setup, Extension
@@ -13,20 +15,32 @@ try:
 except ImportError:
         from distutils.core import setup, Extension
 
-from ConfigParser import ConfigParser
-import sys,os,string,time
+if sys.version_info[0] >= 3:
+    from configparser import ConfigParser
+    from functools import reduce as reduce_fun
+    def string_strip(s):
+        return s.strip()
+    def string_split(s, *args):
+        return s.split(*args)
+else:
+    from ConfigParser import ConfigParser
+    reduce_fun = reduce
+    def string_strip(s):
+        return string.strip(s)
+    def string_split(s, *args):
+        return string.split(s, *args)
 
 ##################################################################
 # Weird Hack to grab release version of python-ldap from local dir
 ##################################################################
 exec_startdir = os.path.dirname(os.path.abspath(sys.argv[0]))
-package_init_file_name = reduce(os.path.join,[exec_startdir,'Lib','ldap','__init__.py'])
+package_init_file_name = reduce_fun(os.path.join,[exec_startdir,'Lib','ldap','__init__.py'])
 f = open(package_init_file_name,'r')
 s = f.readline()
 while s:
-  s = string.strip(s)
+  s = string_strip(s)
   if s[0:11]=='__version__':
-    version = eval(string.split(s,'=')[1])
+    version = eval(string_split(s,'=')[1])
     break
   s = f.readline()
 f.close()
@@ -50,15 +64,15 @@ cfg.read('setup.cfg')
 if cfg.has_section('_ldap'):
   for name in dir(LDAP_CLASS):
     if cfg.has_option('_ldap', name):
-      print name + ': ' + cfg.get('_ldap', name)
-      setattr(LDAP_CLASS, name, string.split(cfg.get('_ldap', name)))
+      print(name + ': ' + cfg.get('_ldap', name))
+      setattr(LDAP_CLASS, name, string_split(cfg.get('_ldap', name)))
 
 for i in range(len(LDAP_CLASS.defines)):
   LDAP_CLASS.defines[i]=((LDAP_CLASS.defines[i],None))
 
 for i in range(len(LDAP_CLASS.extra_files)):
-  destdir, origfiles = string.split(LDAP_CLASS.extra_files[i], ':')
-  origfileslist = string.split(origfiles, ',')
+  destdir, origfiles = string_split(LDAP_CLASS.extra_files[i], ':')
+  origfileslist = string_split(origfiles, ',')
   LDAP_CLASS.extra_files[i]=(destdir, origfileslist)
 
 #-- Let distutils/setuptools do the rest


### PR DESCRIPTION
The Python half of the library passes str (PyUnicode) objects to the C half for
authzid and mech when dealing with SASLObjects. The C half expected these to be
bytes (PyBytes) objects and attempted to convert them to C strings without
checking. This now checks whether each of these objects are PyUnicodes and
encodes them as UTF-8 to create PyBytes objects before continuing as before.
It's UTF-8 as per the SASL spec.

Caveat: This is one of my first forays into Python C-API coding, so please check that this is implemented correctly, particularly around refcounting.
