### PR TITLE
Retire the py3 branch

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,11 @@
+** NOTE **
+
+This is an unofficial branch adding Python 3 support
+to python-ldap. It is now inactive.
+Development of Python 3 support continues in a forked
+project, pyldap: https://github.com/pyldap/pyldap
+
+
 ---------------------------------------
 python-ldap: LDAP client API for Python
 ---------------------------------------


### PR DESCRIPTION
Hi Raphaël,
Some people are still using/linking to your py3 branch. Linking to pyldap in the README should help guide them the right way.
